### PR TITLE
extra checks

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+1.0.1: (Jul 19, 2018)
+ - Hotfix: More defensive checks for possible corrupt caches.
 1.0.0: (Jun 29, 2018)
  - .Track feature
 0.9.4: (May 24, 2018)

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: "maven-publish"
 
 allprojects {
     group = 'io.split.client'
-    version = '1.0.0'
+    version = '1.0.1.rc'
 }
 
 android {
@@ -24,7 +24,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 26
         versionCode 0
-        versionName "1.0.0"
+        versionName "1.0.1.rc"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/src/main/java/io/split/android/client/cache/SplitChangeCache.java
+++ b/src/main/java/io/split/android/client/cache/SplitChangeCache.java
@@ -58,10 +58,12 @@ public class SplitChangeCache implements ISplitChangeCache {
         for (String splitName :
                 _splitCache.getSplitNames()) {
             String cachedSplit = _splitCache.getSplit(splitName);
-            if (cachedSplit != null) {
+            if (cachedSplit != null && !cachedSplit.isEmpty()) {
                 try {
                     Split split = Json.fromJson(cachedSplit, Split.class);
-                    splits.add(split);
+                    if (split != null) {
+                        splits.add(split);
+                    }
                 } catch (JsonSyntaxException e) {
                     Logger.e(e, "Failed to parse split %s, cache: %s", splitName, cachedSplit);
                 }

--- a/src/main/java/io/split/android/engine/experiments/RefreshableSplitFetcher.java
+++ b/src/main/java/io/split/android/engine/experiments/RefreshableSplitFetcher.java
@@ -71,15 +71,18 @@ public class RefreshableSplitFetcher implements SplitFetcher, Runnable {
 
         Map<String, ParsedSplit> toAdd = Maps.newHashMap();
 
-        for (Split split : change.splits) {
-
-            if (split.status == Status.ACTIVE) {
-                ParsedSplit parsedSplit = _parser.parse(split);
-                if (parsedSplit == null) {
-                    Logger.i("We could not parse the experiment definition for: %s so we are removing it completely to be careful", split.name);
-                    continue;
+        if (change.splits != null && !change.splits.isEmpty()) {
+            for (Split split : change.splits) {
+                if (split != null && split.status != null && split.name != null) {
+                    if (Status.ACTIVE.equals(split.status)) {
+                        ParsedSplit parsedSplit = _parser.parse(split);
+                        if (parsedSplit == null) {
+                            Logger.i("We could not parse the experiment definition for: %s so we are removing it completely to be careful", split.name);
+                            continue;
+                        }
+                        toAdd.put(split.name, parsedSplit);
+                    }
                 }
-                toAdd.put(split.name, parsedSplit);
             }
         }
 

--- a/src/main/java/io/split/android/engine/experiments/RefreshableSplitFetcher.java
+++ b/src/main/java/io/split/android/engine/experiments/RefreshableSplitFetcher.java
@@ -71,7 +71,7 @@ public class RefreshableSplitFetcher implements SplitFetcher, Runnable {
 
         Map<String, ParsedSplit> toAdd = Maps.newHashMap();
 
-        if (change.splits != null && !change.splits.isEmpty()) {
+        if (change != null && change.splits != null && !change.splits.isEmpty()) {
             for (Split split : change.splits) {
                 if (split != null && split.status != null && split.name != null) {
                     if (Status.ACTIVE.equals(split.status)) {


### PR DESCRIPTION
Reported problem is that the cached storage might get corrupted. Adding extra defensive code so in case the cache cannot be parsed correctly, simply skip it rather than propagating the error.

I will keep investigating why the cache might be corrupted. But it is hard since it cannot be reproduced locally.