### PR TITLE
SDKS-320: Android Only store Splits in cache when going in background

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+1.2.0: (Sep 24, 2018)
+- Adding split manager feature
 1.1.0: (Aug 28, 2018)
 - Adding get treatments feature
 1.0.2: (Aug 15, 2018)

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.2'
     implementation 'com.google.guava:guava:18.0'
     implementation 'org.apache.httpcomponents:httpclient-android:4.3.5'
-    implementation 'androidx.lifecycle:lifecycle-runtime:2.0.0'
+    implementation "android.arch.lifecycle:extensions:1.1.1"
 
     // Test
     androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.2'
     implementation 'com.google.guava:guava:18.0'
     implementation 'org.apache.httpcomponents:httpclient-android:4.3.5'
+    implementation 'androidx.lifecycle:lifecycle-runtime:2.0.0'
 
     // Test
     androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'maven'
 apply plugin: "maven-publish"
 
 ext {
-    splitVersion = '1.2.3-sdks-320.1'
+    splitVersion = '1.3.1-sdks-320.1'
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: "maven-publish"
 
 allprojects {
     group = 'io.split.client'
-    version = '1.2.0-rc1'
+    version = '1.2.0'
 }
 
 android {
@@ -24,7 +24,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 26
         versionCode 0
-        versionName "1.2.0-rc1"
+        versionName "1.2.0"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'maven'
 apply plugin: "maven-publish"
 
 ext {
-    splitVersion = '1.2.3-sdks-363'
+    splitVersion = '1.2.3-sdks-320.1'
 }
 
 allprojects {

--- a/src/main/java/io/split/android/client/HttpMySegmentsFetcher.java
+++ b/src/main/java/io/split/android/client/HttpMySegmentsFetcher.java
@@ -96,7 +96,7 @@ public final class HttpMySegmentsFetcher implements MySegmentsFetcher {
 
             List<MySegment> mySegmentList = mySegmentsMap.get("mySegments");
 
-            _mySegmentsCache.saveMySegments(matchingKey, mySegmentList);
+            _mySegmentsCache.setMySegments(matchingKey, mySegmentList);
 
             return mySegmentList;
         } catch (Throwable t) {

--- a/src/main/java/io/split/android/client/SplitFactoryImpl.java
+++ b/src/main/java/io/split/android/client/SplitFactoryImpl.java
@@ -141,7 +141,7 @@ public class SplitFactoryImpl implements SplitFactory {
         gates = new SDKReadinessGates();
 
         // Segments
-        IStorage mySegmentsStorage = new MemoryAndFileStorage(context);
+        IStorage mySegmentsStorage = new FileStorage(context);
         MySegmentsFetcher mySegmentsFetcher = HttpMySegmentsFetcher.create(httpclient, rootTarget, mySegmentsStorage);
         final RefreshableMySegmentsFetcherProvider segmentFetcher = new RefreshableMySegmentsFetcherProvider(mySegmentsFetcher, findPollingPeriod(RANDOM, config.segmentsRefreshRate()), key.matchingKey(), _eventsManager);
 

--- a/src/main/java/io/split/android/client/SplitFactoryImpl.java
+++ b/src/main/java/io/split/android/client/SplitFactoryImpl.java
@@ -148,7 +148,7 @@ public class SplitFactoryImpl implements SplitFactory {
         SplitParser splitParser = new SplitParser(segmentFetcher);
 
         // Feature Changes
-        IStorage splitChangeStorage = new MemoryAndFileStorage(context);
+        IStorage splitChangeStorage = new FileStorage(context);
         SplitChangeFetcher splitChangeFetcher = HttpSplitChangeFetcher.create(httpclient, rootTarget, uncachedFireAndForget, splitChangeStorage);
 
         final RefreshableSplitFetcherProvider splitFetcherProvider = new RefreshableSplitFetcherProvider(splitChangeFetcher, splitParser, findPollingPeriod(RANDOM, config.featuresRefreshRate()), _eventsManager);

--- a/src/main/java/io/split/android/client/cache/IMySegmentsCache.java
+++ b/src/main/java/io/split/android/client/cache/IMySegmentsCache.java
@@ -12,12 +12,11 @@ import io.split.android.client.dtos.MySegment;
 public interface IMySegmentsCache {
 
     /**
-     * Saves the list of MySegments in cache
+     * Sets the list of MySegments in cache for a key
      * @param key The key for the list to be saved
      * @param mySegments List of MySegments to cache
-     * @return If it was successfully saved or not
      */
-    boolean saveMySegments(String key, List<MySegment> mySegments);
+    void setMySegments(String key, List<MySegment> mySegments);
 
     /**
      * Gets MySegments from the cache

--- a/src/main/java/io/split/android/client/cache/ISplitCache.java
+++ b/src/main/java/io/split/android/client/cache/ISplitCache.java
@@ -2,6 +2,8 @@ package io.split.android.client.cache;
 
 import java.util.List;
 
+import io.split.android.client.dtos.Split;
+
 /**
  * Created by guillermo on 11/23/17.
  */
@@ -9,11 +11,10 @@ import java.util.List;
 public interface ISplitCache {
     /**
      *
-     * @param splitName Split Name
-     * @param split Split JSON representation
+     * @param split Split
      * @return Whether the Split was added or not
      */
-    boolean addSplit(String splitName, String split);
+    boolean addSplit(Split split);
 
     /**
      *
@@ -40,7 +41,7 @@ public interface ISplitCache {
      * @param splitName Split Name
      * @return Split JSON representation
      */
-    String getSplit(String splitName);
+    Split getSplit(String splitName);
 
     /**
      * Get all cached splits names

--- a/src/main/java/io/split/android/client/cache/MySegmentsCache.java
+++ b/src/main/java/io/split/android/client/cache/MySegmentsCache.java
@@ -4,8 +4,14 @@ import com.google.gson.reflect.TypeToken;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleObserver;
+import androidx.lifecycle.OnLifecycleEvent;
 import io.split.android.client.api.Key;
 import io.split.android.client.dtos.MySegment;
 import io.split.android.client.storage.IStorage;
@@ -16,14 +22,16 @@ import io.split.android.client.utils.Logger;
  * Created by guillermo on 12/28/17.
  */
 
-public class MySegmentsCache implements IMySegmentsCache {
+public class MySegmentsCache implements IMySegmentsCache, LifecycleObserver {
 
     private static final String MY_SEGMENTS_FILE_PREFIX = "SPLITIO.mysegments";
 
     private final IStorage _storage;
+    private final Set<String> _segments;
 
     public MySegmentsCache(IStorage storage) {
         _storage = storage;
+        _segments = Collections.synchronizedSet(new HashSet<>());
     }
 
     private String getMySegmentsId() {
@@ -69,4 +77,31 @@ public class MySegmentsCache implements IMySegmentsCache {
     public void deleteMySegments() {
         _storage.delete(getMySegmentsId());
     }
+
+
+    public void loadFromFile(String key) {
+        try {
+            String savedKey = _storage.read(getMySegmentsKeyId());
+            if (savedKey != null && savedKey.equals(key)) {
+                String storedMySegments = _storage.read(getMySegmentsId());
+                Type listType = new TypeToken<List<MySegment>>() {
+                }.getType();
+
+                List<String> segments = Json.fromJson(storedMySegments, listType);
+                _segments.addAll(segments);
+
+            } else {
+                _storage.delete(getMySegmentsId());
+            }
+        } catch (IOException e) {
+            Logger.e(e, "Unable to get my segments. It could be no segments for this key on disk");
+        }
+    }
+
+    // Lifecyle observer
+    @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+    public void disconnectListener() {
+
+    }
+
 }

--- a/src/main/java/io/split/android/client/cache/SplitCache.java
+++ b/src/main/java/io/split/android/client/cache/SplitCache.java
@@ -108,14 +108,17 @@ public class SplitCache implements ISplitCache, LifecycleObserver {
             return null;
         }
 
+        String splitId = getSplitId(splitName);
+
         try {
-            String splitJson = mFileStorageManager.read(getSplitId(splitName));
+            String splitJson = mFileStorageManager.read(splitId);
             if (splitJson != null && !splitJson.trim().equals("")) {
                 split = Json.fromJson(splitJson, Split.class);
             }
         } catch (IOException e) {
             Logger.e(e, "Unable to load split from disk");
         } catch (JsonSyntaxException syntaxException) {
+            mFileStorageManager.delete(splitId);
             Logger.e(syntaxException, "Unable to parse saved segments");
         }
         return split;

--- a/src/main/java/io/split/android/client/cache/SplitCache.java
+++ b/src/main/java/io/split/android/client/cache/SplitCache.java
@@ -5,6 +5,7 @@ import android.arch.lifecycle.LifecycleObserver;
 import android.arch.lifecycle.OnLifecycleEvent;
 import android.arch.lifecycle.ProcessLifecycleOwner;
 
+import com.google.common.base.Strings;
 import com.google.gson.JsonSyntaxException;
 
 import java.io.IOException;
@@ -103,7 +104,9 @@ public class SplitCache implements ISplitCache, LifecycleObserver {
     private Split getSplitFromDisk(String splitName){
         Split split = null;
 
-        if(splitName == null || splitName.trim().equals("")) return null;
+        if(Strings.isNullOrEmpty(splitName)) {
+            return null;
+        }
 
         try {
             String splitJson = mFileStorageManager.read(getSplitId(splitName));

--- a/src/main/java/io/split/android/client/cache/SplitChangeCache.java
+++ b/src/main/java/io/split/android/client/cache/SplitChangeCache.java
@@ -1,6 +1,5 @@
 package io.split.android.client.cache;
 
-import com.google.gson.JsonParseException;
 import com.google.gson.JsonSyntaxException;
 
 import java.util.ArrayList;
@@ -18,20 +17,19 @@ import io.split.android.client.utils.Logger;
 
 public class SplitChangeCache implements ISplitChangeCache {
 
-    private ISplitCache _splitCache;
+    private ISplitCache mSplitCache;
 
     public SplitChangeCache(IStorage storage) {
-        this._splitCache = new SplitCache(storage);
+        this.mSplitCache = new SplitCache(storage);
     }
 
     @Override
     public boolean addChange(SplitChange splitChange) {
-        if (_splitCache == null) return false;
+        if (mSplitCache == null) return false;
         boolean result = true;
-        _splitCache.setChangeNumber(splitChange.till);
-        for (Split split :
-                splitChange.splits) {
-            result = result && _splitCache.addSplit(split.name, Json.toJson(split));
+        mSplitCache.setChangeNumber(splitChange.till);
+        for (Split split : splitChange.splits) {
+            result = result && mSplitCache.addSplit(split);
         }
         return result;
     }
@@ -39,7 +37,7 @@ public class SplitChangeCache implements ISplitChangeCache {
     @Override
     public SplitChange getChanges(long since) {
 
-        long changeNumber = _splitCache.getChangeNumber();
+        long changeNumber = mSplitCache.getChangeNumber();
 
         SplitChange splitChange = new SplitChange();
 
@@ -55,20 +53,10 @@ public class SplitChangeCache implements ISplitChangeCache {
     }
 
     private void addAllSplits(List<Split> splits) {
-        for (String splitName :
-                _splitCache.getSplitNames()) {
-            String cachedSplit = _splitCache.getSplit(splitName);
-            if (cachedSplit != null && !cachedSplit.isEmpty()) {
-                try {
-                    Split split = Json.fromJson(cachedSplit, Split.class);
-                    if (split != null) {
-                        splits.add(split);
-                    }
-                } catch (JsonSyntaxException e) {
-                    Logger.e(e, "Failed to parse split %s, cache: %s", splitName, cachedSplit);
-                }
-            } else {
-                Logger.w("split %s was not cached", splitName);
+        for (String splitName : mSplitCache.getSplitNames()) {
+            Split cachedSplit = mSplitCache.getSplit(splitName);
+            if (cachedSplit != null) {
+                splits.add(cachedSplit);
             }
         }
     }

--- a/src/main/java/io/split/android/client/storage/FileStorage.java
+++ b/src/main/java/io/split/android/client/storage/FileStorage.java
@@ -90,6 +90,19 @@ public class FileStorage implements IStorage {
     }
 
     @Override
+    public List<String> getAllIds(String fileNamePrefix) {
+        List<String> fileNames = new ArrayList<>();
+        String[] fileList = _context.fileList();
+
+        for(String fileName : fileList) {
+            if(fileName.startsWith(fileNamePrefix)){
+                fileNames.add(fileName);
+            }
+        }
+        return fileNames;
+    }
+
+    @Override
     public boolean rename(String currentId, String newId) {
         File oldFile = _context.getFileStreamPath(currentId);
         File newFile = _context.getFileStreamPath(newId);

--- a/src/main/java/io/split/android/client/storage/IStorage.java
+++ b/src/main/java/io/split/android/client/storage/IStorage.java
@@ -40,6 +40,14 @@ public interface IStorage {
     String[] getAllIds();
 
     /**
+     * Gets all stored element Ids starting with fileNamePrefix
+     *
+     * @param fileNamePrefix Prefix to filter returned ids
+     * @return Array of element Ids
+     */
+    public List<String> getAllIds(String fileNamePrefix);
+
+    /**
      * Changes the Id for an element in the storage
      * @param currentId Current Id
      * @param newId New Id for the element

--- a/src/main/java/io/split/android/client/storage/MemoryAndFileStorage.java
+++ b/src/main/java/io/split/android/client/storage/MemoryAndFileStorage.java
@@ -3,6 +3,7 @@ package io.split.android.client.storage;
 import android.content.Context;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Created by guillermo on 11/24/17.
@@ -50,6 +51,11 @@ public class MemoryAndFileStorage implements IStorage {
     @Override
     public String[] getAllIds() {
         return _fileStorage.getAllIds();
+    }
+
+    @Override
+    public List<String> getAllIds(String fileNamePrefix) {
+        return _fileStorage.getAllIds(fileNamePrefix);
     }
 
     @Override

--- a/src/main/java/io/split/android/client/storage/MemoryStorage.java
+++ b/src/main/java/io/split/android/client/storage/MemoryStorage.java
@@ -1,8 +1,10 @@
 package io.split.android.client.storage;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -34,6 +36,11 @@ public class MemoryStorage implements IStorage {
     public String[] getAllIds() {
         Set<String> allIds = _storage.keySet();
         return allIds.toArray(new String[allIds.size()]);
+    }
+
+    @Override
+    public List<String> getAllIds(String fileNamePrefix) {
+        return new ArrayList(_storage.keySet());
     }
 
     @Override

--- a/src/main/java/io/split/android/client/utils/Utils.java
+++ b/src/main/java/io/split/android/client/utils/Utils.java
@@ -91,13 +91,4 @@ public class Utils {
         }
         return string.replaceAll("[^a-zA-Z0-9\\.\\-]", "_");
     }
-
-    public static String join(String separator, Iterable<String> iterable) {
-        StringBuilder builder = new StringBuilder();
-        for(String string : iterable) {
-            builder.append(string).append(",");
-        }
-        builder.deleteCharAt(builder.length() - 1);
-        return builder.toString();
-    }
 }

--- a/src/main/java/io/split/android/client/utils/Utils.java
+++ b/src/main/java/io/split/android/client/utils/Utils.java
@@ -91,4 +91,13 @@ public class Utils {
         }
         return string.replaceAll("[^a-zA-Z0-9\\.\\-]", "_");
     }
+
+    public static String join(String separator, Iterable<String> iterable) {
+        StringBuilder builder = new StringBuilder();
+        for(String string : iterable) {
+            builder.append(string).append(",");
+        }
+        builder.deleteCharAt(builder.length() - 1);
+        return builder.toString();
+    }
 }

--- a/src/test/java/io/split/android/engine/segments/MySegmentsCacheTest.java
+++ b/src/test/java/io/split/android/engine/segments/MySegmentsCacheTest.java
@@ -1,0 +1,101 @@
+package io.split.android.engine.segments;
+
+import org.junit.Assert;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.split.android.client.cache.IMySegmentsCache;
+import io.split.android.client.cache.MySegmentsCache;
+import io.split.android.client.dtos.MySegment;
+import io.split.android.client.storage.IStorage;
+import io.split.android.client.storage.MemoryStorage;
+import io.split.android.client.utils.Utils;
+
+public class MySegmentsCacheTest {
+
+    IMySegmentsCache mCache = null;
+
+    @Before
+    public void setupUp(){
+        final String JSON_SEGMENT_TEMPLATE = "{\"id\":\"id-%d-%d\", \"name\":\"segment-%d-%d\"}";
+        final String FILE_PREFIX = "SPLITIO.mysegments";
+        final String ALL_KEYS_FILE = FILE_PREFIX + ".allKeys";
+        List<String > allKeys = new ArrayList<>();
+        IStorage memStorage = new MemoryStorage();
+
+        for(int i = 0; i < 3; i++) {
+            String key = String.format("key-%d", i);
+            allKeys.add(key);
+            List<String> segments  = new ArrayList<>();
+
+            for(int j = 0; j < 4; j++) {
+                segments.add(String.format(JSON_SEGMENT_TEMPLATE, i, j, i, j));
+            }
+            final String jsonSegments = "[" + String.join(",", segments) + "]";
+            try {
+                memStorage.write(FILE_PREFIX + "_" + key, jsonSegments);
+            } catch (IOException e) {
+            }
+        }
+        try {
+            memStorage.write(ALL_KEYS_FILE, Utils.join(",", allKeys));
+        } catch (IOException e) {
+        }
+        mCache = new MySegmentsCache(memStorage);
+    }
+
+    @Test
+    public void getMySegments() {
+
+        List<MySegment> segments0 = mCache.getMySegments("key-0");
+        List<MySegment> segments1 = mCache.getMySegments("key-1");
+        List<MySegment> segments2 = mCache.getMySegments("key-2");
+
+        Assert.assertEquals(4, segments0.size());
+        Assert.assertEquals("id-0-0", segments0.get(0).id);
+        Assert.assertEquals("id-0-2", segments0.get(2).id);
+
+        Assert.assertEquals(4, segments1.size());
+        Assert.assertEquals("id-1-1", segments1.get(1).id);
+        Assert.assertEquals("id-1-2", segments1.get(2).id);
+
+        Assert.assertEquals(4, segments2.size());
+        Assert.assertEquals("id-2-0", segments2.get(0).id);
+        Assert.assertEquals("id-2-2", segments2.get(2).id);
+    }
+
+    @Test
+    public void setMySegments() {
+        String key = "key-0";
+        List<MySegment> segments = mCache.getMySegments(key);
+        MySegment segment = new MySegment();
+        segment.id = "id-test-1";
+        segment.name = "test-1";
+        segments.add(segment);
+        mCache.setMySegments(key, segments);
+
+        List<MySegment> segmentsTest = mCache.getMySegments(key);
+        Assert.assertEquals(5, segmentsTest.size());
+        Assert.assertEquals("id-test-1", segmentsTest.get(4).id);
+    }
+
+    @Test
+    public void deleteMySegments() {
+        String key1 = "key-1";
+        String key2 = "key-2";
+        mCache.deleteMySegments(key1);
+        mCache.deleteMySegments(key2);
+
+        List<MySegment> segments1 = mCache.getMySegments(key1);
+        List<MySegment> segments2 = mCache.getMySegments(key2);
+
+        Assert.assertNull(segments1);
+        Assert.assertNull(segments2);
+    }
+
+}

--- a/src/test/java/io/split/android/engine/splits/SplitCacheTest.java
+++ b/src/test/java/io/split/android/engine/splits/SplitCacheTest.java
@@ -1,0 +1,108 @@
+package io.split.android.engine.splits;
+
+import org.junit.Assert;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.split.android.client.cache.IMySegmentsCache;
+import io.split.android.client.cache.ISplitCache;
+import io.split.android.client.cache.SplitCache;
+import io.split.android.client.dtos.MySegment;
+import io.split.android.client.dtos.Split;
+import io.split.android.client.storage.IStorage;
+import io.split.android.client.storage.MemoryStorage;
+import io.split.android.client.utils.Utils;
+
+public class SplitCacheTest {
+
+    ISplitCache mCache = null;
+
+    final static Long INITIAL_CHANGE_NUMBER = 44L;
+
+    @Before
+    public void setupUp(){
+
+
+        final String CHANGE_NUMBER_FILE = "SPLITIO.changeNumber";
+        final String FILE_PREFIX = "SPLITIO.split.";
+        final String JSON_SPLIT_TEMPLATE = "{\"name\":\"%s\"}";
+
+        IStorage memStorage = new MemoryStorage();
+
+        for(int i = 0; i < 4; i++) {
+            String splitName = "split-" + i;
+            try {
+                memStorage.write(FILE_PREFIX + splitName, String.format(JSON_SPLIT_TEMPLATE, splitName));
+            } catch (IOException e) {
+            }
+        }
+
+        try {
+            memStorage.write(CHANGE_NUMBER_FILE, String.valueOf(INITIAL_CHANGE_NUMBER));
+        } catch (IOException e) {
+        }
+        mCache = new SplitCache(memStorage);
+    }
+
+    @Test
+    public void getSplits() {
+
+        Split split0 = mCache.getSplit("split-0");
+        Split split1 = mCache.getSplit("split-1");
+        Split split2 = mCache.getSplit("split-2");
+        Split split3 = mCache.getSplit("split-3");
+
+        Assert.assertNotNull(split0);
+        Assert.assertNotNull(split1);
+        Assert.assertNotNull(split2);
+        Assert.assertNotNull(split3);
+    }
+
+    @Test
+    public void addSplits() {
+        for(int i=0; i<4; i++) {
+            String splitName = "split-test-" + i;
+            Split split = new Split();
+            split.name = splitName;
+            mCache.addSplit(split);
+        }
+
+        for(int i=0; i<4; i++) {
+            String splitName = "split-test-" + i;
+            Split splitTest = mCache.getSplit(splitName);
+            Assert.assertNotNull(splitTest);
+            Assert.assertEquals(splitName, splitTest.name);
+        }
+    }
+
+    @Test
+    public void deleteSplit() {
+        String split0 = "split-0";
+        String split3 = "split-3";
+        mCache.removeSplit(split0);
+        mCache.removeSplit(split3);
+
+        Assert.assertNull(mCache.getSplit(split0));
+        Assert.assertNull(mCache.getSplit(split3));
+        Assert.assertNotNull(mCache.getSplit("split-1"));
+    }
+
+    @Test
+    public void initialChangeNumber() {
+        Assert.assertTrue(INITIAL_CHANGE_NUMBER == mCache.getChangeNumber());
+    }
+
+    @Test
+    public void updateChangeNumber() {
+        final Long NEW_CHANGE_NUMBER = 70000L;
+        mCache.setChangeNumber(NEW_CHANGE_NUMBER);
+        Assert.assertTrue(NEW_CHANGE_NUMBER == mCache.getChangeNumber());
+    }
+
+}
+


### PR DESCRIPTION
- Update Split cache to save split cache on disk on app background
- Storing split cache in memory in native objects instead of json 
- Modified ISplitCache interface
- Updated SplitChangeCache to interact correctly with Split Cache
- Added unit test for Split Cache component