### PR TITLE
SDKS-316: Android Only store Impressions in cache when going in background

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'maven'
 apply plugin: "maven-publish"
 
 ext {
-    splitVersion = '1.2.3-sdks-316.1'
+    splitVersion = '1.3.1-sdks-316.1'
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'maven'
 apply plugin: "maven-publish"
 
 ext {
-    splitVersion = '1.2.3-sdks-363'
+    splitVersion = '1.2.3-sdks-316.1'
 }
 
 allprojects {

--- a/src/main/java/io/split/android/client/SplitClientConfig.java
+++ b/src/main/java/io/split/android/client/SplitClientConfig.java
@@ -232,11 +232,24 @@ public class SplitClientConfig {
         return _hostname;
     }
 
+    /**
+     * Maximum attempts count while sending impressions.
+     * to the server. Internal setting.
+     *
+     * @return Maximum attempts limit.
+     */
+
     int impressionsMaxSentAttempts() {
         return _impressionsMaxSentAttempts;
     }
 
-    long impressionsChunkOudatedTime() {
+    /**
+     * Elapsed time in millis to consider that a chunk of impression
+     * is outdated. Internal property
+     *
+     * @return Time in millis.
+     */
+    long impressionsChunkOutdatedTime() {
         return _impressionsChunkOudatedTime;
     }
 
@@ -602,6 +615,11 @@ public class SplitClientConfig {
             return this;
         }
 
+        /**
+         * The current proxy host.
+         *
+         * @return an HttpHost representing current proxy
+         */
         HttpHost proxy() {
             if (_proxyPort != -1) {
                 return new HttpHost(_proxyHost, _proxyPort);

--- a/src/main/java/io/split/android/client/SplitClientConfig.java
+++ b/src/main/java/io/split/android/client/SplitClientConfig.java
@@ -25,6 +25,9 @@ public class SplitClientConfig {
     private final int _segmentsRefreshRate;
     private final int _impressionsRefreshRate;
     private final int _impressionsQueueSize;
+    private final int _impressionsMaxSentAttempts = 3;
+    private final long _impressionsChunkOudatedTime = 3600 * 1000; // One day millis
+
     private final int _metricsRefreshRate;
     private final int _connectionTimeout;
     private final int _readTimeout;
@@ -104,6 +107,8 @@ public class SplitClientConfig {
         _eventsPerPush = eventsPerPush;
         _eventFlushInterval = eventFlushInterval;
         _trafficType = trafficType;
+
+
 
         Properties props = new Properties();
         try {
@@ -225,6 +230,14 @@ public class SplitClientConfig {
 
     public String hostname() {
         return _hostname;
+    }
+
+    int impressionsMaxSentAttempts() {
+        return _impressionsMaxSentAttempts;
+    }
+
+    long impressionsChunkOudatedTime() {
+        return _impressionsChunkOudatedTime;
     }
 
     public String ip() {

--- a/src/main/java/io/split/android/client/SplitFactoryImpl.java
+++ b/src/main/java/io/split/android/client/SplitFactoryImpl.java
@@ -47,7 +47,6 @@ import io.split.android.client.metrics.FireAndForgetMetrics;
 import io.split.android.client.metrics.HttpMetrics;
 import io.split.android.client.storage.FileStorage;
 import io.split.android.client.storage.IStorage;
-import io.split.android.client.storage.MemoryAndFileStorage;
 import io.split.android.client.track.TrackStorageManager;
 import io.split.android.client.utils.Logger;
 import io.split.android.engine.SDKReadinessGates;
@@ -157,7 +156,7 @@ public class SplitFactoryImpl implements SplitFactory {
         // Impressions
         ImpressionsStorageManagerConfig impressionsStorageManagerConfig = new ImpressionsStorageManagerConfig();
         impressionsStorageManagerConfig.setImpressionsMaxSentAttempts(config.impressionsMaxSentAttempts());
-        impressionsStorageManagerConfig.setImpressionsChunkOudatedTime(config.impressionsChunkOudatedTime());
+        impressionsStorageManagerConfig.setImpressionsChunkOudatedTime(config.impressionsChunkOutdatedTime());
         IStorage impressionsStorage = new FileStorage(context);
         final ImpressionsStorageManager impressionsStorageManager = new ImpressionsStorageManager(impressionsStorage, impressionsStorageManagerConfig);
         final ImpressionsManager splitImpressionListener = ImpressionsManager.instance(httpclient, config, impressionsStorageManager);

--- a/src/main/java/io/split/android/client/SplitFactoryImpl.java
+++ b/src/main/java/io/split/android/client/SplitFactoryImpl.java
@@ -38,6 +38,7 @@ import io.split.android.client.events.SplitEventsManager;
 import io.split.android.client.impressions.ImpressionListener;
 import io.split.android.client.impressions.ImpressionsManager;
 import io.split.android.client.impressions.ImpressionsStorageManager;
+import io.split.android.client.impressions.ImpressionsStorageManagerConfig;
 import io.split.android.client.interceptors.AddSplitHeadersFilter;
 import io.split.android.client.interceptors.GzipDecoderResponseInterceptor;
 import io.split.android.client.interceptors.GzipEncoderRequestInterceptor;
@@ -154,8 +155,11 @@ public class SplitFactoryImpl implements SplitFactory {
         final RefreshableSplitFetcherProvider splitFetcherProvider = new RefreshableSplitFetcherProvider(splitChangeFetcher, splitParser, findPollingPeriod(RANDOM, config.featuresRefreshRate()), _eventsManager);
 
         // Impressions
+        ImpressionsStorageManagerConfig impressionsStorageManagerConfig = new ImpressionsStorageManagerConfig();
+        impressionsStorageManagerConfig.setImpressionsMaxSentAttempts(config.impressionsMaxSentAttempts());
+        impressionsStorageManagerConfig.setImpressionsChunkOudatedTime(config.impressionsChunkOudatedTime());
         IStorage impressionsStorage = new FileStorage(context);
-        final ImpressionsStorageManager impressionsStorageManager = new ImpressionsStorageManager(impressionsStorage);
+        final ImpressionsStorageManager impressionsStorageManager = new ImpressionsStorageManager(impressionsStorage, impressionsStorageManagerConfig);
         final ImpressionsManager splitImpressionListener = ImpressionsManager.instance(httpclient, config, impressionsStorageManager);
         final ImpressionListener impressionListener;
 

--- a/src/main/java/io/split/android/client/impressions/ImpressionsManager.java
+++ b/src/main/java/io/split/android/client/impressions/ImpressionsManager.java
@@ -167,5 +167,4 @@ public class ImpressionsManager implements ImpressionListener, Runnable {
         long size = Utils.toJsonEntity(keyImpression).getContentLength();
         _currentChunkSize += size;
     }
-
 }

--- a/src/main/java/io/split/android/client/impressions/ImpressionsManager.java
+++ b/src/main/java/io/split/android/client/impressions/ImpressionsManager.java
@@ -1,5 +1,7 @@
 package io.split.android.client.impressions;
 
+import android.util.Log;
+
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -17,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 
 import io.split.android.client.SplitClientConfig;
 import io.split.android.client.dtos.KeyImpression;
+import io.split.android.client.dtos.TestImpressions;
 import io.split.android.client.utils.Logger;
 import io.split.android.client.utils.Utils;
 
@@ -91,6 +94,7 @@ public class ImpressionsManager implements ImpressionListener, Runnable {
             _scheduler.shutdown();
             flushImpressions();
             sendImpressions();
+            _storageManager.close();
             _scheduler.awaitTermination(_config.waitBeforeShutdown(), TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             Logger.e(e, "Unable to close ImpressionsManager");
@@ -155,6 +159,7 @@ public class ImpressionsManager implements ImpressionListener, Runnable {
                 _storageManager.failedStoredImpression(storedImpression);
             }
         }
+
         Logger.d("Posting Split impressions took %d millis", (System.currentTimeMillis() - start));
     }
 

--- a/src/main/java/io/split/android/client/impressions/ImpressionsStorageManager.java
+++ b/src/main/java/io/split/android/client/impressions/ImpressionsStorageManager.java
@@ -95,6 +95,10 @@ public class ImpressionsStorageManager implements LifecycleObserver {
         }
     }
 
+    public void close(){
+        saveToDisk();
+    }
+
     private boolean chunkCanBeStored(StoredImpressions storedImpressions) {
         if (storedImpressions == null) {
             return false;

--- a/src/main/java/io/split/android/client/impressions/ImpressionsStorageManager.java
+++ b/src/main/java/io/split/android/client/impressions/ImpressionsStorageManager.java
@@ -142,7 +142,7 @@ public class ImpressionsStorageManager implements LifecycleObserver {
 
         try {
             String storedImpressions = mFileStorageManager.read(IMPRESSIONS_FILE_NAME);
-            if(storedImpressions.isEmpty()) {
+            if(Strings.isNullOrEmpty(storedImpressions)) {
                 return;
             }
 

--- a/src/main/java/io/split/android/client/impressions/ImpressionsStorageManagerConfig.java
+++ b/src/main/java/io/split/android/client/impressions/ImpressionsStorageManagerConfig.java
@@ -1,0 +1,22 @@
+package io.split.android.client.impressions;
+
+public class ImpressionsStorageManagerConfig {
+    private int _impressionsMaxSentAttempts = 0;
+    private long _impressionsChunkOudatedTime = 0;
+
+    public int getImpressionsMaxSentAttempts() {
+        return _impressionsMaxSentAttempts;
+    }
+
+    public void setImpressionsMaxSentAttempts(int impressionsMaxSendAttempts) {
+        this._impressionsMaxSentAttempts = impressionsMaxSendAttempts;
+    }
+
+    public long getImpressionsChunkOudatedTime() {
+        return _impressionsChunkOudatedTime;
+    }
+
+    public void setImpressionsChunkOudatedTime(long impressionsChunkOudatedTime) {
+        this._impressionsChunkOudatedTime = impressionsChunkOudatedTime;
+    }
+}

--- a/src/main/java/io/split/android/client/impressions/StoredImpressions.java
+++ b/src/main/java/io/split/android/client/impressions/StoredImpressions.java
@@ -29,7 +29,6 @@ public class StoredImpressions {
     public List<TestImpressions> impressions() {
         return impressions;
     }
-
     public int  getAttempts(){
         return attempts;
     }
@@ -38,13 +37,8 @@ public class StoredImpressions {
         attempts++;
     }
 
-    public boolean isDeprecated() {
-        long diff = System.currentTimeMillis() - timestamp;
-
-        long oneDayMillis = 3600 * 1000;
-        if (diff > oneDayMillis) {
-            return true;
-        }
-        return false;
+    public long getTimestamp() {
+        return timestamp;
     }
+
 }

--- a/src/main/java/io/split/android/client/impressions/StoredImpressions.java
+++ b/src/main/java/io/split/android/client/impressions/StoredImpressions.java
@@ -9,14 +9,17 @@ import io.split.android.client.dtos.TestImpressions;
 public class StoredImpressions {
     private final String id;
     private final List<TestImpressions> impressions;
+    private int attempts = 0;
+    private long timestamp = 0;
 
-    public static StoredImpressions from(String id, List<TestImpressions> impressions) {
-        return new StoredImpressions(id, impressions);
+    public static StoredImpressions from(String id, List<TestImpressions> impressions, long timestamp) {
+        return new StoredImpressions(id, impressions, timestamp);
     }
 
-    private StoredImpressions(String id, List<TestImpressions> impressions) {
+    private StoredImpressions(String id, List<TestImpressions> impressions, long timestamp) {
         this.id = Preconditions.checkNotNull(id);
         this.impressions = Preconditions.checkNotNull(impressions);
+        this.timestamp = timestamp;
     }
 
     public String id() {
@@ -25,5 +28,23 @@ public class StoredImpressions {
 
     public List<TestImpressions> impressions() {
         return impressions;
+    }
+
+    public int  getAttempts(){
+        return attempts;
+    }
+
+    public void addAttempt(){
+        attempts++;
+    }
+
+    public boolean isDeprecated() {
+        long diff = System.currentTimeMillis() - timestamp;
+
+        long oneDayMillis = 3600 * 1000;
+        if (diff > oneDayMillis) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/test/java/io/split/android/client/impressions/ImpressionsManagerTest.java
+++ b/src/test/java/io/split/android/client/impressions/ImpressionsManagerTest.java
@@ -38,7 +38,7 @@ public class ImpressionsManagerTest {
                 .build();
 
         ImpressionsSender senderMock = Mockito.mock(ImpressionsSender.class);
-        ImpressionsStorageManager storageMock = new ImpressionsStorageManager(new MemoryStorage());
+        ImpressionsStorageManager storageMock = new ImpressionsStorageManager(new MemoryStorage(), storageConfig());
 
         ImpressionsManager treatmentLog = ImpressionsManager.instanceForTest(null, config, senderMock, storageMock);
 
@@ -72,7 +72,7 @@ public class ImpressionsManagerTest {
                 .build();
 
         ImpressionsSender senderMock = Mockito.mock(ImpressionsSender.class);
-        ImpressionsStorageManager storageMock = new ImpressionsStorageManager(new MemoryStorage());
+        ImpressionsStorageManager storageMock = new ImpressionsStorageManager(new MemoryStorage(), storageConfig());
 
         ImpressionsManager treatmentLog = ImpressionsManager.instanceForTest(null, config, senderMock, storageMock);
 
@@ -107,7 +107,7 @@ public class ImpressionsManagerTest {
                 .build();
 
         ImpressionsSender senderMock = Mockito.mock(ImpressionsSender.class);
-        ImpressionsStorageManager storageMock = new ImpressionsStorageManager(new MemoryStorage());
+        ImpressionsStorageManager storageMock = new ImpressionsStorageManager(new MemoryStorage(), storageConfig());
 
         ImpressionsManager treatmentLog = ImpressionsManager.instanceForTest(null, config, senderMock, storageMock);
 
@@ -144,7 +144,7 @@ public class ImpressionsManagerTest {
                 .build();
 
         ImpressionsSender senderMock = Mockito.mock(ImpressionsSender.class);
-        ImpressionsStorageManager storageMock = new ImpressionsStorageManager(new MemoryStorage());
+        ImpressionsStorageManager storageMock = new ImpressionsStorageManager(new MemoryStorage(), storageConfig());
 
         ImpressionsManager treatmentLog = ImpressionsManager.instanceForTest(null, config, senderMock, storageMock);
 
@@ -164,6 +164,13 @@ public class ImpressionsManagerTest {
         result.time = time;
         result.changeNumber = changeNumber;
         return result;
+    }
+
+    private ImpressionsStorageManagerConfig storageConfig() {
+        ImpressionsStorageManagerConfig config = new ImpressionsStorageManagerConfig();
+        config.setImpressionsChunkOudatedTime(3600000);
+        config.setImpressionsMaxSentAttempts(3);
+        return config;
     }
 
 }

--- a/src/test/java/io/split/android/engine/impressions/ImpressionsStorageTest.java
+++ b/src/test/java/io/split/android/engine/impressions/ImpressionsStorageTest.java
@@ -1,0 +1,194 @@
+package io.split.android.engine.impressions;
+
+        import org.junit.Assert;
+
+        import org.junit.Before;
+        import org.junit.Test;
+
+        import java.io.IOException;
+        import java.util.ArrayList;
+        import java.util.HashMap;
+        import java.util.HashSet;
+        import java.util.List;
+        import java.util.Map;
+        import java.util.Set;
+
+        import io.split.android.client.dtos.KeyImpression;
+        import io.split.android.client.dtos.TestImpressions;
+        import io.split.android.client.impressions.ImpressionsStorageManager;
+        import io.split.android.client.impressions.StoredImpressions;
+        import io.split.android.client.storage.IStorage;
+        import io.split.android.client.storage.MemoryStorage;
+        import io.split.android.client.utils.Json;
+
+public class ImpressionsStorageTest {
+
+    ImpressionsStorageManager mImpStorage = null;
+
+    @Before
+    public void setupUp(){
+
+        final String FILE_NAME = "SPLITIO.impressions";
+
+
+        Map<String, StoredImpressions> storedImpressions = new HashMap<>();
+        IStorage memStorage = new MemoryStorage();
+        final int CHUNK_COUNT = 4;
+        for(int i = 0; i < CHUNK_COUNT; i++) {
+            String chunkId = String.format("chunk-%d", i);
+            List<TestImpressions> testImpressions  = new ArrayList<>();
+            for(int j = 0; j < 4; j++) {
+
+                String featureName = String.format("feature-%d-%d", i, j);
+                List<KeyImpression> impressions  = new ArrayList<>();
+                for(int k = 0; k < 4; k++) {
+                    KeyImpression impression = new KeyImpression();
+                    impression.feature = featureName;
+                    impression.keyName = String.format("name-%d-%d-%d", i, j, k);
+                    impression.treatment = String.format("treatment-%d-%d-%d", i, j, k);
+                    impressions.add(impression);
+                }
+                TestImpressions testImpressionsDTO = new TestImpressions();
+                testImpressionsDTO.testName = featureName;
+                testImpressionsDTO.keyImpressions = impressions;
+                testImpressions.add(testImpressionsDTO);
+            }
+
+            long timestamp = System.currentTimeMillis();
+            if(i == CHUNK_COUNT -1){
+                timestamp = timestamp - 3600 * 1000 * 2; // Two day millis, chunck is deprecated and should not be loaded
+            }
+            StoredImpressions storedImpressionsItem = StoredImpressions.from(chunkId, testImpressions, timestamp);
+            storedImpressions.put(chunkId, storedImpressionsItem);
+        }
+        try {
+            String allImpressionsJson = Json.toJson(storedImpressions);
+            memStorage.write(FILE_NAME, allImpressionsJson);
+        } catch (IOException e) {
+        }
+        mImpStorage = new ImpressionsStorageManager(memStorage);
+    }
+
+    @Test
+    public void getStoredImpressions() {
+
+        List<StoredImpressions> storedImpressions = mImpStorage.getStoredImpressions();
+
+        Assert.assertEquals(3, storedImpressions.size());
+        Assert.assertNotEquals(-1, getIndexForStoredImpression("chunk-0", storedImpressions));
+        Assert.assertNotEquals(-1, getIndexForStoredImpression("chunk-1", storedImpressions));
+        Assert.assertNotEquals(-1, getIndexForStoredImpression("chunk-2", storedImpressions));
+
+        StoredImpressions storedImpression = storedImpressions.get(getIndexForStoredImpression("chunk-0", storedImpressions));
+        Assert.assertEquals(4, storedImpression.impressions().size());
+        List<TestImpressions> testImpressions = storedImpression.impressions();
+        Assert.assertEquals(4, testImpressions.size());
+        Assert.assertEquals("feature-0-0", testImpressions.get(0).testName);
+        Assert.assertEquals(4, testImpressions.get(0).keyImpressions.size());
+        Assert.assertEquals("feature-0-3", testImpressions.get(3).testName);
+    }
+
+    @Test
+    public void storeImpressions(){
+        List<KeyImpression> impressions  = new ArrayList<>();
+        for(int j = 0; j < 2; j++) {
+            String featureName = String.format("feature-test-%d", j);
+            for(int k = 0; k < 4; k++) {
+                KeyImpression impression = new KeyImpression();
+                impression.feature = featureName;
+                impression.keyName = String.format("name-%d-%d", j, k);
+                impression.treatment = String.format("treatment-%d-%d", j, k);
+                impressions.add(impression);
+            }
+        }
+        try {
+            mImpStorage.storeImpressions(impressions);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        List<StoredImpressions> storedImpressions = mImpStorage.getStoredImpressions();
+
+        Assert.assertEquals(4, storedImpressions.size());
+        StoredImpressions storedImpression = storedImpressions.get(getIndexForUUIDStoredImpression(storedImpressions));
+        List<TestImpressions> testImpressions = storedImpression.impressions();
+        Assert.assertEquals(2, testImpressions.size());
+
+        Set<String> testNames = new HashSet<>();
+        testNames.add(testImpressions.get(0).testName);
+        testNames.add(testImpressions.get(1).testName);
+        Assert.assertTrue(testNames.contains("feature-test-0"));
+        Assert.assertTrue(testNames.contains("feature-test-1"));
+        Assert.assertEquals(4, testImpressions.get(0).keyImpressions.size());
+        Assert.assertEquals(4, testImpressions.get(1).keyImpressions.size());
+    }
+
+
+    @Test
+    public void impressionsSentSuccess() {
+
+        List<StoredImpressions> storedImpressions = mImpStorage.getStoredImpressions();
+
+        StoredImpressions chunk1 = storedImpressions.get(getIndexForStoredImpression("chunk-1", storedImpressions));
+        mImpStorage.succeededStoredImpression(chunk1);
+        storedImpressions = mImpStorage.getStoredImpressions();
+
+        Assert.assertEquals(2, storedImpressions.size());
+        Assert.assertEquals(-1, getIndexForStoredImpression("chunk-1", storedImpressions));
+        Assert.assertNotEquals(-1, getIndexForStoredImpression("chunk-0", storedImpressions));
+        Assert.assertNotEquals(-1, getIndexForStoredImpression("chunk-2", storedImpressions));
+    }
+
+    @Test
+    public void impressionsSentFailure() {
+
+        List<StoredImpressions> storedImpressions = mImpStorage.getStoredImpressions();
+        StoredImpressions chunk1 = storedImpressions.get(getIndexForStoredImpression("chunk-1", storedImpressions));
+        mImpStorage.failedStoredImpression(chunk1);
+        storedImpressions = mImpStorage.getStoredImpressions();
+
+        int chunk1Index = getIndexForStoredImpression("chunk-1", storedImpressions);
+        Assert.assertTrue(chunk1Index > -1);
+
+        chunk1 = storedImpressions.get(chunk1Index);
+
+        Assert.assertEquals(3, storedImpressions.size());
+        Assert.assertEquals(1, chunk1.getAttempts());
+    }
+
+
+    // Helpers
+    private int getIndexForStoredImpression(String chunkId, List<StoredImpressions> impressions) {
+
+        int index = -1;
+        int i = 0;
+        boolean found = false;
+
+        while(!found && impressions.size() > i){
+            String id = impressions.get(i).id();
+            if(chunkId.equals(id)){
+                found = true;
+                index = i;
+            }
+            i++;
+        }
+        return index;
+    }
+
+    private int getIndexForUUIDStoredImpression(List<StoredImpressions> impressions) {
+
+        int index = -1;
+        int i = 0;
+        boolean found = false;
+
+        while(!found && impressions.size() > i){
+            String id = impressions.get(i).id();
+            if(!id.contains("chunk")){
+                found = true;
+                index = i;
+            }
+            i++;
+        }
+        return index;
+    }
+}


### PR DESCRIPTION
- Storing impressions in memory instead of saving to disk when generated
- Saving to disk when app goes to background or Split client is closed
- Added unit tests to ImpressionsStorageManager component