### PR TITLE
Avoid big binding when delete

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 2.6.6: (Ago 03, 2020)
-- Added filters to fetch especific split when synchronizing
+- Added filters to fetch specific split when synchronizing
 
 2.6.5: (Jul 20, 2020)
 - Improved logic to refresh streaming token

--- a/src/main/java/io/split/android/client/storage/splits/SqLitePersistentSplitsStorage.java
+++ b/src/main/java/io/split/android/client/storage/splits/SqLitePersistentSplitsStorage.java
@@ -3,6 +3,7 @@ package io.split.android.client.storage.splits;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.google.common.collect.Lists;
 import com.google.gson.JsonSyntaxException;
 
 import java.util.ArrayList;
@@ -19,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class SqLitePersistentSplitsStorage implements PersistentSplitsStorage {
 
+    private static final int SQL_PARAM_BIND_SIZE = 20;
     SplitRoomDatabase mDatabase;
 
     public SqLitePersistentSplitsStorage(@NonNull SplitRoomDatabase database) {
@@ -75,7 +77,11 @@ public class SqLitePersistentSplitsStorage implements PersistentSplitsStorage {
 
     @Override
     public void delete(List<String> splitNames) {
-        mDatabase.splitDao().delete(splitNames);
+        // This is to avoid an sqlite error if there are many split to delete
+        List<List<String>> deleteChunk = Lists.partition(splitNames, SQL_PARAM_BIND_SIZE);
+        for(List<String> splitName : deleteChunk) {
+            mDatabase.splitDao().delete(splitNames);
+        }
     }
 
     @Override


### PR DESCRIPTION
# Android SDK

## What did you accomplish?
Some defensive code to avoid issues when deleting splits. Splits array to deleted partitioned y smaller arrays to avoid to many sqlite bind variable error when running delete statement.