### PR TITLE
Add @Transaction on every @Query Room method

### DIFF
--- a/src/main/java/io/split/android/client/storage/db/EventDao.java
+++ b/src/main/java/io/split/android/client/storage/db/EventDao.java
@@ -12,18 +12,22 @@ public interface EventDao {
     @Insert
     public void insert(EventEntity event);
 
+    @Transaction
     @Query("SELECT id, body, created_at, status FROM events " +
             "WHERE created_at >= :updateAt " +
             "AND status = :status ORDER BY created_at LIMIT :maxRows")
     List<EventEntity> getBy(long updateAt, int status, int maxRows);
 
+    @Transaction
     @Query("UPDATE events SET status = :status "  +
             " WHERE id IN (:ids)")
     void updateStatus(List<Long> ids, int status);
 
+    @Transaction
     @Query("DELETE FROM events WHERE id IN (:ids)")
     void delete(List<Long> ids);
 
+    @Transaction
     @Query("DELETE FROM events WHERE created_at < :updateAt")
     void deleteOutdated(long updateAt);
 

--- a/src/main/java/io/split/android/client/storage/db/GeneralInfoDao.java
+++ b/src/main/java/io/split/android/client/storage/db/GeneralInfoDao.java
@@ -6,6 +6,7 @@ import androidx.room.Dao;
 import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
+import androidx.room.Transaction;
 import androidx.room.Update;
 
 import java.util.List;
@@ -16,6 +17,7 @@ public interface GeneralInfoDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     void update(GeneralInfoEntity info);
 
+    @Transaction
     @Query("SELECT name, stringValue, longValue, updated_at FROM general_info WHERE name = :name")
     GeneralInfoEntity getByName(String name);
 }

--- a/src/main/java/io/split/android/client/storage/db/ImpressionDao.java
+++ b/src/main/java/io/split/android/client/storage/db/ImpressionDao.java
@@ -4,6 +4,7 @@ import androidx.room.Dao;
 import androidx.room.Delete;
 import androidx.room.Insert;
 import androidx.room.Query;
+import androidx.room.Transaction;
 import androidx.room.Update;
 
 import java.util.List;
@@ -18,18 +19,22 @@ public interface ImpressionDao {
     @Insert
     void insert(List<ImpressionEntity> impressions);
 
+    @Transaction
     @Query("SELECT id, test_name, body, created_at, status FROM impressions " +
             "WHERE created_at >= :timestamp " +
             "AND status = :status ORDER BY created_at LIMIT :maxRows")
     List<ImpressionEntity> getBy(long timestamp, int status, int maxRows);
 
+    @Transaction
     @Query("UPDATE impressions SET status = :status " +
             " WHERE id IN (:ids)")
     void updateStatus(List<Long> ids, int status);
 
+    @Transaction
     @Query("DELETE FROM impressions WHERE id IN (:ids)")
     void delete(List<Long> ids);
 
+    @Transaction
     @Query("DELETE FROM impressions WHERE created_at < :timestamp")
     void deleteOutdated(long timestamp);
 

--- a/src/main/java/io/split/android/client/storage/db/MySegmentDao.java
+++ b/src/main/java/io/split/android/client/storage/db/MySegmentDao.java
@@ -5,6 +5,7 @@ import androidx.room.Dao;
 import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
+import androidx.room.Transaction;
 import androidx.room.Update;
 
 import java.util.List;
@@ -17,6 +18,7 @@ public interface MySegmentDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     void update(MySegmentEntity mySegment);
 
+    @Transaction
     @Query("SELECT user_key, segment_list, updated_at FROM my_segments WHERE user_key = :userKey")
     MySegmentEntity getByUserKeys(String userKey);
 }

--- a/src/main/java/io/split/android/client/storage/db/SplitDao.java
+++ b/src/main/java/io/split/android/client/storage/db/SplitDao.java
@@ -4,6 +4,7 @@ import androidx.room.Dao;
 import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
+import androidx.room.Transaction;
 
 import java.util.List;
 
@@ -12,12 +13,15 @@ public interface SplitDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     void insert(List<SplitEntity> splits);
 
+    @Transaction
     @Query("DELETE FROM splits WHERE name IN (:names)")
     void delete(List<String> names);
 
+    @Transaction
     @Query("SELECT name, body, updated_at FROM splits")
     List<SplitEntity> getAll();
 
+    @Transaction
     @Query("DELETE FROM splits")
     void deleteAll();
 }


### PR DESCRIPTION
# Android SDK
Solving [this](https://github.com/splitio/android-client/issues/222#issue-784764130) issue with add @Transaction to handle big query 

## What did you accomplish?

- added @Transaction on each @Query Room method

## Extra Notes
As  written in [doc](https://developer.android.com/reference/androidx/room/Transaction) : Room will only perform at most one transaction at a time, additional transactions are queued and executed on a first come, first serve order. 