### PR TITLE
Modify set method behaviour in attributes storage

### DIFF
--- a/src/main/java/io/split/android/client/storage/attributes/AttributesStorageImpl.java
+++ b/src/main/java/io/split/android/client/storage/attributes/AttributesStorageImpl.java
@@ -19,7 +19,8 @@ public class AttributesStorageImpl implements AttributesStorage {
     @Override
     public void loadLocal() {
         if (mPersistentAttributesStorage != null) {
-            overwriteValuesInMemory(mPersistentAttributesStorage.getAll());
+            mInMemoryAttributes.clear();
+            mInMemoryAttributes.putAll(mPersistentAttributesStorage.getAll());
         }
     }
 
@@ -48,10 +49,10 @@ public class AttributesStorageImpl implements AttributesStorage {
     public void set(@Nullable Map<String, Object> attributes) {
         if (attributes == null) return;
 
-        overwriteValuesInMemory(attributes);
+        mInMemoryAttributes.putAll(attributes);
 
         if (mPersistentAttributesStorage != null) {
-            mPersistentAttributesStorage.set(attributes);
+            mPersistentAttributesStorage.set(mInMemoryAttributes);
         }
     }
 
@@ -75,10 +76,5 @@ public class AttributesStorageImpl implements AttributesStorage {
         if (mPersistentAttributesStorage != null) {
             mPersistentAttributesStorage.set(mInMemoryAttributes);
         }
-    }
-
-    private void overwriteValuesInMemory(Map<String, Object> values) {
-        mInMemoryAttributes.clear();
-        mInMemoryAttributes.putAll(values);
     }
 }

--- a/src/test/java/io/split/android/client/storage/attributes/AttributesStorageImplTest.java
+++ b/src/test/java/io/split/android/client/storage/attributes/AttributesStorageImplTest.java
@@ -3,6 +3,7 @@ package io.split.android.client.storage.attributes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -12,7 +13,6 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 public class AttributesStorageImplTest {
 

--- a/src/test/java/io/split/android/client/storage/attributes/AttributesStorageImplTest.java
+++ b/src/test/java/io/split/android/client/storage/attributes/AttributesStorageImplTest.java
@@ -12,12 +12,14 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class AttributesStorageImplTest {
 
     @Mock
     private PersistentAttributesStorage persistentAttributesStorage;
     private AttributesStorageImpl attributesStorage;
+    private HashMap<String, Object> defaultValuesMap = null;
 
     @Before
     public void setUp() {
@@ -105,6 +107,28 @@ public class AttributesStorageImplTest {
 
         assertTrue(attributesStorage.getAll().entrySet().containsAll(getDefaultValuesMap().entrySet()));
         assertTrue(attributesStorage.getAll().containsKey("newKey"));
+    }
+
+    @Test
+    public void setMultipleNewValuesRetainsPreviousValues() {
+        Map<String, Object> newValues = new HashMap<>();
+        newValues.put("newKey", "newValue");
+        newValues.put("newKey2", "newValue2");
+        newValues.put("key1", "newValue1");
+
+        Map<String, Object> expectedValues = new HashMap<>();
+        expectedValues.put("newKey", "newValue");
+        expectedValues.put("newKey2", "newValue2");
+        expectedValues.put("key1", "newValue1");
+        expectedValues.put("key2", "value2");
+        expectedValues.put("key3", "value3");
+
+        attributesStorage.set(getDefaultValuesMap());
+        attributesStorage.set(newValues);
+
+        Map<String, Object> entries = attributesStorage.getAll();
+        assertEquals(5, entries.size());
+        assertEquals(expectedValues, entries);
     }
 
     @Test
@@ -202,10 +226,12 @@ public class AttributesStorageImplTest {
     }
 
     private Map<String, Object> getDefaultValuesMap() {
-        HashMap<String, Object> defaultValuesMap = new HashMap<>();
-        defaultValuesMap.put("key1", "value1");
-        defaultValuesMap.put("key2", "value2");
-        defaultValuesMap.put("key3", "value3");
+        if (defaultValuesMap == null) {
+            defaultValuesMap = new HashMap<>();
+            defaultValuesMap.put("key1", "value1");
+            defaultValuesMap.put("key2", "value2");
+            defaultValuesMap.put("key3", "value3");
+        }
 
         return defaultValuesMap;
     }


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

Changed behavior in `set(Map<String, Object> attributes)` method in attributes storage. It should add / update values instead of clearing and reseting.