### PR TITLE
[SDKS-5325] Replace key encoding for segments path

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+2.8.0: (Nov 19, 2021)
+- Added Attribute binding feature to allow to optionally keep user attributes loaded within the SDK, along with the user ID, for easier usage when requesting flag.
+- Updated localhost mode by converting yaml and properties config to split rollout rules.
+
 2.7.4: (Oct 28, 2021)
 - Added support for a user key containing a slash character.
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 }
 
 ext {
-    splitVersion = '2.7.4'
+    splitVersion = '2.8.0'
 }
 
 android {

--- a/src/main/java/io/split/android/client/network/SdkTargetPath.java
+++ b/src/main/java/io/split/android/client/network/SdkTargetPath.java
@@ -1,6 +1,7 @@
 package io.split.android.client.network;
 
 import com.google.common.base.Strings;
+import com.google.common.net.UrlEscapers;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -22,12 +23,7 @@ public class SdkTargetPath {
     }
 
     public static final URI mySegments(String baseUrl, String key) throws URISyntaxException {
-        String encodedKey = key;
-        try {
-            encodedKey = URLEncoder.encode(key, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            Logger.e("Could not encode user key: " + key + " error -> " + e.getLocalizedMessage());
-        }
+        String encodedKey = key != null ? UrlEscapers.urlPathSegmentEscaper().escape(key) : null;
         return buildUrl(baseUrl, MY_SEGMENTS + "/" + encodedKey);
     }
 

--- a/src/main/java/io/split/android/client/network/SdkTargetPath.java
+++ b/src/main/java/io/split/android/client/network/SdkTargetPath.java
@@ -3,12 +3,8 @@ package io.split.android.client.network;
 import com.google.common.base.Strings;
 import com.google.common.net.UrlEscapers;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLEncoder;
-
-import io.split.android.client.utils.Logger;
 
 public class SdkTargetPath {
     public static final String SPLIT_CHANGES = "/splitChanges";

--- a/src/test/java/io/split/android/client/network/SdkTargetPathTest.java
+++ b/src/test/java/io/split/android/client/network/SdkTargetPathTest.java
@@ -1,0 +1,33 @@
+package io.split.android.client.network;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class SdkTargetPathTest {
+
+    @Test
+    public void userKeyWithSpaces() throws URISyntaxException {
+        URI uri = SdkTargetPath.mySegments("https://split.io", "CABM, CCIB Marketing");
+
+        assertEquals("/mySegments/CABM,%20CCIB%20Marketing", uri.getRawPath());
+    }
+
+    @Test
+    public void userKeyWithSlash() throws URISyntaxException {
+        URI uri = SdkTargetPath.mySegments("https://split.io", "user/key");
+
+        assertEquals("/mySegments/user%2Fkey", uri.getRawPath());
+    }
+
+    @Test
+    public void userKeyWithSpecialChars() throws URISyntaxException {
+        URI uri = SdkTargetPath.mySegments("https://split.io", "grüneStraße");
+
+        assertEquals("/mySegments/gr%C3%BCneStra%C3%9Fe", uri.getRawPath());
+    }
+
+}

--- a/src/test/java/io/split/android/client/network/SdkTargetPathTest.java
+++ b/src/test/java/io/split/android/client/network/SdkTargetPathTest.java
@@ -29,5 +29,4 @@ public class SdkTargetPathTest {
 
         assertEquals("/mySegments/gr%C3%BCneStra%C3%9Fe", uri.getRawPath());
     }
-
 }


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Modified encoding for user key when building path segment for `mySegments` request.
- Added tests.