### PR TITLE
Remove sizeInBytes field from serialization in EventDTO

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 ext {
-    splitVersion = '2.9.1-rc1'
+    splitVersion = '2.9.1-rc2'
 }
 
 android {

--- a/src/main/java/io/split/android/client/dtos/Event.java
+++ b/src/main/java/io/split/android/client/dtos/Event.java
@@ -16,7 +16,7 @@ public class Event implements InBytesSizable, Identifiable {
     public Map<String,Object> properties;
 
     transient public long storageId;
-    private int sizeInBytes = 0;
+    transient private int sizeInBytes = 0;
 
     @Override
     public boolean equals(Object o) {


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Removed `sizeInBytes` field from Events DTO.