### PR TITLE
Dynamically load attributes from cache when a new client is created

### DIFF
--- a/src/main/java/io/split/android/client/SplitFactoryImpl.java
+++ b/src/main/java/io/split/android/client/SplitFactoryImpl.java
@@ -4,7 +4,6 @@ import android.content.Context;
 
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
@@ -37,6 +36,7 @@ import io.split.android.client.service.synchronizer.Synchronizer;
 import io.split.android.client.service.synchronizer.SynchronizerImpl;
 import io.split.android.client.service.synchronizer.SynchronizerSpy;
 import io.split.android.client.service.synchronizer.WorkManagerWrapper;
+import io.split.android.client.service.synchronizer.attributes.AttributesSynchronizerRegistryImpl;
 import io.split.android.client.shared.SplitClientContainer;
 import io.split.android.client.shared.SplitClientContainerImpl;
 import io.split.android.client.storage.SplitStorageContainer;
@@ -160,7 +160,8 @@ public class SplitFactoryImpl implements SplitFactory {
                 mEventsManagerCoordinator,
                 workManagerWrapper,
                 new RetryBackoffCounterTimerFactory(),
-                mStorageContainer.getTelemetryStorage());
+                mStorageContainer.getTelemetryStorage(),
+                new AttributesSynchronizerRegistryImpl());
 
         // Only available for integration tests
         if (synchronizerSpy != null) {

--- a/src/main/java/io/split/android/client/service/synchronizer/attributes/AttributesSynchronizerRegistryImpl.java
+++ b/src/main/java/io/split/android/client/service/synchronizer/attributes/AttributesSynchronizerRegistryImpl.java
@@ -1,0 +1,33 @@
+package io.split.android.client.service.synchronizer.attributes;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class AttributesSynchronizerRegistryImpl implements AttributesSynchronizerRegistry, AttributesSynchronizer {
+
+    private final AtomicBoolean mLoadedAttributesFromCache = new AtomicBoolean(false);
+    private final ConcurrentMap<String, AttributesSynchronizer> mAttributesSynchronizers = new ConcurrentHashMap<>();
+
+    @Override
+    public synchronized void registerAttributesSynchronizer(String userKey, AttributesSynchronizer attributesSynchronizer) {
+        mAttributesSynchronizers.put(userKey, attributesSynchronizer);
+        if (mLoadedAttributesFromCache.get()) {
+            attributesSynchronizer.loadAttributesFromCache();
+        }
+    }
+
+    @Override
+    public void unregisterAttributesSynchronizer(String userKey) {
+        mAttributesSynchronizers.remove(userKey);
+    }
+
+    @Override
+    public synchronized void loadAttributesFromCache() {
+        for (AttributesSynchronizer attributesSynchronizer : mAttributesSynchronizers.values()) {
+            attributesSynchronizer.loadAttributesFromCache();
+        }
+
+        mLoadedAttributesFromCache.set(true);
+    }
+}

--- a/src/main/java/io/split/android/client/shared/ClientComponentsRegisterImpl.java
+++ b/src/main/java/io/split/android/client/shared/ClientComponentsRegisterImpl.java
@@ -62,9 +62,9 @@ public class ClientComponentsRegisterImpl implements ClientComponentsRegister {
         mAttributesSynchronizerRegistry = checkNotNull(attributesSynchronizerRegistry);
         mMySegmentsSynchronizerRegistry = checkNotNull(mySegmentsSynchronizerRegistry);
         mMySegmentsUpdateWorkerRegistry = checkNotNull(mySegmentsUpdateWorkerRegistry);
+        mMySegmentsNotificationProcessorRegistry = checkNotNull(mySegmentsNotificationProcessorRegistry);
         mEventsManagerRegistry = checkNotNull(eventsManagerRegistry);
         mSseAuthenticator = checkNotNull(sseAuthenticator);
-        mMySegmentsNotificationProcessorRegistry = checkNotNull(mySegmentsNotificationProcessorRegistry);
         mDefaultMatchingKey = checkNotNull(defaultMatchingKey);
         mMySegmentsNotificationProcessorFactory = checkNotNull(mySegmentsNotificationProcessorFactory);
         mMySegmentsV2PayloadDecoder = checkNotNull(mySegmentsV2PayloadDecoder);

--- a/src/test/java/io/split/android/client/service/synchronizer/attributes/AttributesSynchronizerRegistryImplTest.java
+++ b/src/test/java/io/split/android/client/service/synchronizer/attributes/AttributesSynchronizerRegistryImplTest.java
@@ -1,0 +1,42 @@
+package io.split.android.client.service.synchronizer.attributes;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class AttributesSynchronizerRegistryImplTest {
+
+    private AttributesSynchronizerRegistryImpl mRegistry;
+
+    @Before
+    public void setUp() {
+        mRegistry = new AttributesSynchronizerRegistryImpl();
+    }
+
+    @Test
+    public void loadAttributesFromCacheTriggersRegisteredSynchronizers() {
+        AttributesSynchronizer syncMock = mock(AttributesSynchronizer.class);
+        AttributesSynchronizer syncMock2 = mock(AttributesSynchronizer.class);
+        mRegistry.registerAttributesSynchronizer("key", syncMock);
+        mRegistry.registerAttributesSynchronizer("key2", syncMock2);
+
+        mRegistry.loadAttributesFromCache();
+
+        verify(syncMock).loadAttributesFromCache();
+        verify(syncMock2).loadAttributesFromCache();
+    }
+
+    @Test
+    public void loadAttributesFromCacheIsTriggeredForNewlyRegisteredSyncIfNecessary() {
+        AttributesSynchronizer syncMock = mock(AttributesSynchronizer.class);
+        AttributesSynchronizer syncMock2 = mock(AttributesSynchronizer.class);
+        mRegistry.registerAttributesSynchronizer("key", syncMock);
+
+        mRegistry.loadAttributesFromCache();
+
+        mRegistry.registerAttributesSynchronizer("key2", syncMock2);
+        verify(syncMock2).loadAttributesFromCache();
+    }
+}

--- a/src/test/java/io/split/android/client/service/telemetry/SynchronizerImplTelemetryTest.java
+++ b/src/test/java/io/split/android/client/service/telemetry/SynchronizerImplTelemetryTest.java
@@ -33,6 +33,7 @@ import io.split.android.client.service.splits.SplitsSyncTask;
 import io.split.android.client.service.sseclient.sseclient.RetryBackoffCounterTimer;
 import io.split.android.client.service.synchronizer.SynchronizerImpl;
 import io.split.android.client.service.synchronizer.WorkManagerWrapper;
+import io.split.android.client.service.synchronizer.attributes.AttributesSynchronizerRegistryImpl;
 import io.split.android.client.storage.SplitStorageContainer;
 import io.split.android.client.storage.events.PersistentEventsStorage;
 import io.split.android.client.storage.impressions.PersistentImpressionsStorage;
@@ -77,6 +78,8 @@ public class SynchronizerImplTelemetryTest {
     WorkManagerWrapper mWorkManagerWrapper;
     @Mock
     SplitClientConfig mConfig;
+    @Mock
+    AttributesSynchronizerRegistryImpl mAttributesSynchronizerRegistry;
 
     private SynchronizerImpl mSynchronizer;
 
@@ -108,8 +111,8 @@ public class SynchronizerImplTelemetryTest {
                 mEventsManager,
                 mWorkManagerWrapper,
                 mRetryBackoffCounterFactory,
-                mTelemetryRuntimeProducer
-        );
+                mTelemetryRuntimeProducer,
+                mAttributesSynchronizerRegistry);
     }
 
     @Test


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

Trigger attributes loading after a new client is created, if needed.