### PR TITLE
Modify SplitFactory methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 ext {
-    splitVersion = '2.9.1'
+    splitVersion = '2.10.0-rc1'
 }
 
 android {

--- a/src/main/java/io/split/android/client/SplitFactory.java
+++ b/src/main/java/io/split/android/client/SplitFactory.java
@@ -5,8 +5,11 @@ import io.split.android.client.api.Key;
 public interface SplitFactory {
     SplitClient client();
     SplitClient client(Key key);
+    SplitClient client(String matchingKey);
+    SplitClient client(String matchingKey, String bucketingKey);
     SplitManager manager();
     void destroy();
     void flush();
+    @Deprecated
     boolean isReady();
 }

--- a/src/main/java/io/split/android/client/SplitFactory.java
+++ b/src/main/java/io/split/android/client/SplitFactory.java
@@ -10,6 +10,12 @@ public interface SplitFactory {
     SplitManager manager();
     void destroy();
     void flush();
+
+    /**
+     * Deprecated: Use {@link SplitClient#isReady()}
+     *
+     * @return Whether at least one client instance is ready.
+     */
     @Deprecated
     boolean isReady();
 }

--- a/src/main/java/io/split/android/client/SplitFactoryImpl.java
+++ b/src/main/java/io/split/android/client/SplitFactoryImpl.java
@@ -306,6 +306,16 @@ public class SplitFactoryImpl implements SplitFactory {
     }
 
     @Override
+    public SplitClient client(String matchingKey) {
+        return mClientContainer.getClient(new Key(matchingKey));
+    }
+
+    @Override
+    public SplitClient client(String matchingKey, String bucketingKey) {
+        return mClientContainer.getClient(new Key(matchingKey, bucketingKey));
+    }
+
+    @Override
     public SplitManager manager() {
         return mManager;
     }
@@ -325,6 +335,7 @@ public class SplitFactoryImpl implements SplitFactory {
     }
 
     @Override
+    @Deprecated
     public boolean isReady() {
         Set<SplitClient> clients = mClientContainer.getAll();
         for (SplitClient client : clients) {

--- a/src/main/java/io/split/android/client/localhost/LocalhostSplitFactory.java
+++ b/src/main/java/io/split/android/client/localhost/LocalhostSplitFactory.java
@@ -105,6 +105,16 @@ public class LocalhostSplitFactory implements SplitFactory {
     }
 
     @Override
+    public SplitClient client(String matchingKey) {
+        return mClientContainer.getClient(new Key(matchingKey));
+    }
+
+    @Override
+    public SplitClient client(String matchingKey, String bucketingKey) {
+        return mClientContainer.getClient(new Key(matchingKey, bucketingKey));
+    }
+
+    @Override
     public SplitManager manager() {
         return mManager;
     }

--- a/src/main/java/io/split/android/client/shared/ClientComponentsRegisterImpl.java
+++ b/src/main/java/io/split/android/client/shared/ClientComponentsRegisterImpl.java
@@ -125,7 +125,7 @@ public class ClientComponentsRegisterImpl implements ClientComponentsRegister {
 
     private void registerMySegmentsNotificationProcessor(Key key, MySegmentsTaskFactory mySegmentsTaskFactory, LinkedBlockingDeque<MySegmentChangeNotification> notificationsQueue) {
         MySegmentsNotificationProcessor processor = getMySegmentsNotificationProcessor(key, mySegmentsTaskFactory, notificationsQueue);
-        mMySegmentsNotificationProcessorRegistry.registerMySegmentsProcessor(mDefaultMatchingKey, processor);
+        mMySegmentsNotificationProcessorRegistry.registerMySegmentsProcessor(key.matchingKey(), processor);
     }
 
     private MySegmentsNotificationProcessor getMySegmentsNotificationProcessor(Key key, MySegmentsTaskFactory mySegmentsTaskFactory, LinkedBlockingDeque<MySegmentChangeNotification> mySegmentUpdateNotificationsQueue) {


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Added convenience methods for client retrieval in `SplitFactory`.
- Deprecated `isReady()` method in `SplitFactory`.
- Fixed bug in `MySegmentsNotificationProcessor` registration.