### PR TITLE
Delegate notification processing to corresponding MySegmentsNotificationProcessor

### DIFF
--- a/src/main/java/io/split/android/client/SplitFactoryImpl.java
+++ b/src/main/java/io/split/android/client/SplitFactoryImpl.java
@@ -25,6 +25,7 @@ import io.split.android.client.service.executor.SplitTaskFactory;
 import io.split.android.client.service.executor.SplitTaskFactoryImpl;
 import io.split.android.client.service.sseclient.SseJwtParser;
 import io.split.android.client.service.sseclient.feedbackchannel.PushManagerEventBroadcaster;
+import io.split.android.client.service.sseclient.notifications.MySegmentsPayloadDecoder;
 import io.split.android.client.service.sseclient.notifications.NotificationParser;
 import io.split.android.client.service.sseclient.notifications.NotificationProcessor;
 import io.split.android.client.service.sseclient.notifications.SplitsChangeNotification;
@@ -175,7 +176,7 @@ public class SplitFactoryImpl implements SplitFactory {
         NotificationParser notificationParser = new NotificationParser();
 
         NotificationProcessor notificationProcessor = new NotificationProcessor(splitTaskExecutor, splitTaskFactory,
-                notificationParser, splitsUpdateNotificationQueue);
+                notificationParser, splitsUpdateNotificationQueue, new MySegmentsPayloadDecoder());
 
         PushManagerEventBroadcaster pushManagerEventBroadcaster = new PushManagerEventBroadcaster();
 

--- a/src/main/java/io/split/android/client/service/sseclient/notifications/MySegmentsPayloadDecoder.java
+++ b/src/main/java/io/split/android/client/service/sseclient/notifications/MySegmentsPayloadDecoder.java
@@ -22,7 +22,7 @@ public class MySegmentsPayloadDecoder {
 
             return Base64.encodeToString(murmurHashStringBytes, Base64.NO_WRAP);
         } catch (Exception exception) {
-            Logger.e(exception);
+            Logger.e("An error occurred when encoding matching key");
 
             return "";
         }

--- a/src/main/java/io/split/android/client/service/sseclient/notifications/MySegmentsPayloadDecoder.java
+++ b/src/main/java/io/split/android/client/service/sseclient/notifications/MySegmentsPayloadDecoder.java
@@ -1,0 +1,30 @@
+package io.split.android.client.service.sseclient.notifications;
+
+import android.util.Base64;
+
+import androidx.annotation.NonNull;
+
+import io.split.android.client.utils.Logger;
+import io.split.android.client.utils.MurmurHash3;
+import io.split.android.client.utils.StringHelper;
+
+public class MySegmentsPayloadDecoder {
+
+    /**
+     * @param matchingKey plain matching key.
+     * @return Base64 encoding of {@param matchingKey} murmur3_32 hash.
+     */
+    @NonNull
+    public String hashUserKeyForMySegmentsV1(String matchingKey) {
+        try {
+            long murmurHash = MurmurHash3.murmurhash3_x86_32(matchingKey, 0, matchingKey.length(), 0);
+            byte[] murmurHashStringBytes = String.valueOf(murmurHash).getBytes(StringHelper.defaultCharset());
+
+            return Base64.encodeToString(murmurHashStringBytes, Base64.NO_WRAP);
+        } catch (Exception exception) {
+            Logger.e(exception);
+
+            return "";
+        }
+    }
+}

--- a/src/main/java/io/split/android/client/service/sseclient/notifications/MySegmentsV2PayloadDecoder.java
+++ b/src/main/java/io/split/android/client/service/sseclient/notifications/MySegmentsV2PayloadDecoder.java
@@ -2,17 +2,12 @@ package io.split.android.client.service.sseclient.notifications;
 
 import java.math.BigInteger;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import io.split.android.client.exceptions.MySegmentsParsingException;
 import io.split.android.client.utils.Base64Util;
 import io.split.android.client.utils.CompressionUtil;
 import io.split.android.client.utils.MurmurHash3;
 import io.split.android.client.utils.StringHelper;
-
-import static java.lang.Math.abs;
 
 public class MySegmentsV2PayloadDecoder {
 

--- a/src/main/java/io/split/android/client/service/sseclient/notifications/NotificationParser.java
+++ b/src/main/java/io/split/android/client/service/sseclient/notifications/NotificationParser.java
@@ -1,22 +1,16 @@
 package io.split.android.client.service.sseclient.notifications;
 
+import static io.split.android.client.service.sseclient.notifications.NotificationType.OCCUPANCY;
+
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
-import com.google.gson.JsonParseException;
 import com.google.gson.JsonSyntaxException;
-import com.google.gson.reflect.TypeToken;
 
-import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.Map;
 
-import io.split.android.client.exceptions.MySegmentsParsingException;
 import io.split.android.client.utils.Json;
 import io.split.android.client.utils.Logger;
-import io.split.android.client.utils.StringHelper;
-
-import static io.split.android.client.service.sseclient.notifications.NotificationType.ERROR;
-import static io.split.android.client.service.sseclient.notifications.NotificationType.OCCUPANCY;
 
 public class NotificationParser {
     private final static String EVENT_TYPE_ERROR = "error";
@@ -87,5 +81,17 @@ public class NotificationParser {
 
     public boolean isError(Map<String, String> values) {
         return values != null && EVENT_TYPE_ERROR.equals(values.get(EVENT_TYPE_FIELD));
+    }
+
+    @Nullable
+    public String extractUserKeyHashFromChannel(String channel) {
+        if (channel != null) {
+            String[] split = channel.split("_");
+            if (split.length > 1) {
+                return split[2];
+            }
+        }
+
+        return null;
     }
 }

--- a/src/main/java/io/split/android/client/service/sseclient/notifications/NotificationParser.java
+++ b/src/main/java/io/split/android/client/service/sseclient/notifications/NotificationParser.java
@@ -86,9 +86,9 @@ public class NotificationParser {
     @Nullable
     public String extractUserKeyHashFromChannel(String channel) {
         if (channel != null) {
-            String[] split = channel.split("_");
-            if (split.length > 1) {
-                return split[2];
+            String[] channelSegments = channel.split("_");
+            if (channelSegments.length > 2) {
+                return channelSegments[2];
             }
         }
 

--- a/src/test/java/android/util/Base64.java
+++ b/src/test/java/android/util/Base64.java
@@ -1,0 +1,13 @@
+package android.util;
+
+/**
+ * android.util.Base64 is not available for unit tests.
+ *
+ * We can't use java.util.Base64 due to our minSdk, however for unit tests it's fine.
+ */
+public class Base64 {
+
+    public static String encodeToString(byte[] input, int flags) {
+        return java.util.Base64.getEncoder().encodeToString(input);
+    }
+}

--- a/src/test/java/io/split/android/client/service/sseclient/notifications/MySegmentsPayloadDecoderTest.java
+++ b/src/test/java/io/split/android/client/service/sseclient/notifications/MySegmentsPayloadDecoderTest.java
@@ -1,0 +1,23 @@
+package io.split.android.client.service.sseclient.notifications;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class MySegmentsPayloadDecoderTest {
+
+    private MySegmentsPayloadDecoder mMySegmentsPayloadDecoder;
+
+    @Before
+    public void setUp() {
+        mMySegmentsPayloadDecoder = new MySegmentsPayloadDecoder();
+    }
+
+    @Test
+    public void encodingOfUserKeyWorksAsExpected() {
+        String expectedResult = "MjAwNjI0Nzg3NQ==";
+
+        assertEquals(expectedResult, mMySegmentsPayloadDecoder.hashUserKeyForMySegmentsV1("user_key"));
+    }
+}


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

Delegate notification processing to corresponding `MySegmentsNotificationProcessor` instance.

This is done by replicating a portion of the encoded string that's present in the channel property of the notification and comparing against each registered processor.