### PR TITLE
Events json deserializer

### DIFF
--- a/src/androidTest/java/tests/integration/TrackTest.java
+++ b/src/androidTest/java/tests/integration/TrackTest.java
@@ -193,6 +193,8 @@ public class TrackTest {
         Assert.assertEquals(1, trackCount.get(2).intValue());
         Assert.assertEquals(3, trackCount.get(3).intValue());
 
+        Thread.sleep(2000);
+
         Event e1 = findEvent("event1", 0.0);
         Event e2 = findEvent("event2", 2.0);
         Event e3 = findEvent("event3", 3.0);
@@ -255,15 +257,12 @@ public class TrackTest {
         properties.put("id", 158576837);
         client.track("user", "long-number-event", 1, properties);
         mLatchs.get(0).await(20, TimeUnit.SECONDS);
+        Thread.sleep(500);
         Event event = findEvent("long-number-event", 1.0);
 
         assertNotNull(event);
         assertEquals(24584535, event.properties.get("price"));
         assertEquals(158576837, event.properties.get("id"));
-    }
-
-    private void log(String m) {
-        System.out.println("FACTORY_TEST: " + m);
     }
 
     private String emptyChanges() {

--- a/src/androidTest/java/tests/integration/TrackTest.java
+++ b/src/androidTest/java/tests/integration/TrackTest.java
@@ -1,5 +1,8 @@
 package tests.integration;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import android.content.Context;
 
 import androidx.test.platform.app.InstrumentationRegistry;
@@ -10,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -17,7 +21,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
+import helper.DatabaseHelper;
 import helper.ImpressionListenerHelper;
 import helper.IntegrationHelper;
 import helper.SplitEventTaskHelper;
@@ -111,11 +117,9 @@ public class TrackTest {
     @Test
     public void test() throws Exception {
         ArrayList<Integer> trackCount = new ArrayList<>();
-        ArrayList<String> treatments = new ArrayList<>();
         CountDownLatch latch = new CountDownLatch(1);
-        String apiKey = "99049fd8653247c5ea42bc3c1ae2c6a42bc3";
-        String dataFolderName = "2a1099049fd8653247c5ea42bOIajMRhH0R0FcBwJZM4ca7zj6HAq1ZDS";
-        SplitRoomDatabase splitRoomDatabase = SplitRoomDatabase.getDatabase(mContext, dataFolderName);
+        String apiKey = IntegrationHelper.dummyApiKey();
+        SplitRoomDatabase splitRoomDatabase = DatabaseHelper.getTestDatabase(mContext);
         splitRoomDatabase.clearAllTables();
         splitRoomDatabase.generalInfoDao().update(new GeneralInfoEntity(GeneralInfoEntity.DATBASE_MIGRATION_STATUS, GeneralInfoEntity.DATBASE_MIGRATION_STATUS_DONE));
 
@@ -196,17 +200,66 @@ public class TrackTest {
         Assert.assertEquals("custom", e1.trafficTypeName);
         Assert.assertEquals(0.0, e1.value, 0.0);
         Assert.assertEquals("event1", e1.eventTypeId);
-        Assert.assertEquals(0, ((Double) e1.properties.get("value")).intValue());
+        Assert.assertEquals(0, (e1.properties.get("value")));
 
         Assert.assertEquals("custom", e2.trafficTypeName);
         Assert.assertEquals(2.0, e2.value, 0.0);
         Assert.assertEquals("event2", e2.eventTypeId);
-        Assert.assertEquals(2, ((Double) e2.properties.get("value")).intValue());
+        Assert.assertEquals(2, (e2.properties.get("value")));
 
         Assert.assertEquals("custom", e3.trafficTypeName);
         Assert.assertEquals(3.0, e3.value, 0.0);
         Assert.assertEquals("event3", e3.eventTypeId);
-        Assert.assertEquals(3, ((Double) e3.properties.get("value")).intValue());
+        Assert.assertEquals(3, (e3.properties.get("value")));
+    }
+
+    @Test
+    public void largeNumberInPropertiesTest() throws InterruptedException, IOException, URISyntaxException, TimeoutException {
+        CountDownLatch latch = new CountDownLatch(1);
+        String apiKey = IntegrationHelper.dummyApiKey();
+        SplitRoomDatabase splitRoomDatabase = DatabaseHelper.getTestDatabase(mContext);
+        splitRoomDatabase.clearAllTables();
+        splitRoomDatabase.generalInfoDao().update(new GeneralInfoEntity(GeneralInfoEntity.DATBASE_MIGRATION_STATUS, GeneralInfoEntity.DATBASE_MIGRATION_STATUS_DONE));
+
+        final String url = mWebServer.url("/").url().toString();
+
+        Key key = new Key("CUSTOMER_ID", null);
+        SplitClientConfig config = new TestableSplitConfigBuilder()
+                .serviceEndpoints(ServiceEndpoints
+                        .builder()
+                        .apiEndpoint(url)
+                        .eventsEndpoint(url)
+                        .build())
+                .ready(30000)
+                .eventFlushInterval(5)
+                .eventsPerPush(5)
+                .eventsQueueSize(1000)
+                .enableDebug()
+                .trafficType("client")
+                .build();
+
+        SplitFactory splitFactory = SplitFactoryBuilder.build(apiKey, key, config, mContext);
+
+        SplitClient client = splitFactory.client();
+
+        SplitEventTaskHelper readyTask = new SplitEventTaskHelper(latch);
+        SplitEventTaskHelper readyTimeOutTask = new SplitEventTaskHelper(latch);
+
+        client.on(SplitEvent.SDK_READY, readyTask);
+        client.on(SplitEvent.SDK_READY_TIMED_OUT, readyTimeOutTask);
+
+        latch.await(20, TimeUnit.SECONDS);
+
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put("price", 24584535);
+        properties.put("id", 158576837);
+        client.track("user", "long-number-event", 1, properties);
+        mLatchs.get(0).await(20, TimeUnit.SECONDS);
+        Event event = findEvent("long-number-event", 1.0);
+
+        assertNotNull(event);
+        assertEquals(24584535, event.properties.get("price"));
+        assertEquals(158576837, event.properties.get("id"));
     }
 
     private void log(String m) {

--- a/src/main/java/io/split/android/client/dtos/Event.java
+++ b/src/main/java/io/split/android/client/dtos/Event.java
@@ -1,10 +1,18 @@
 package io.split.android.client.dtos;
 
-import io.split.android.client.storage.InBytesSizable;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
 
+import io.split.android.client.storage.InBytesSizable;
+import io.split.android.client.utils.deserializer.EventDeserializer;
+
+@JsonAdapter(EventDeserializer.class)
 public class Event extends SerializableEvent implements InBytesSizable, Identifiable {
 
+    public static final String SIZE_IN_BYTES_FIELD = "sizeInBytes";
+
     transient public long storageId;
+    @SerializedName(SIZE_IN_BYTES_FIELD)
     private int sizeInBytes = 0;
 
     public void setSizeInBytes(int sizeInBytes) {

--- a/src/main/java/io/split/android/client/dtos/SerializableEvent.java
+++ b/src/main/java/io/split/android/client/dtos/SerializableEvent.java
@@ -1,16 +1,30 @@
 package io.split.android.client.dtos;
 
 import com.google.common.base.Objects;
+import com.google.gson.annotations.SerializedName;
 
 import java.util.Map;
 
 public class SerializableEvent {
 
+    public static final String EVENT_TYPE_FIELD = "eventTypeId";
+    public static final String TRAFFIC_TYPE_NAME_FIELD = "trafficTypeName";
+    public static final String KEY_FIELD = "key";
+    public static final String VALUE_FIELD = "value";
+    public static final String TIMESTAMP_FIELD = "timestamp";
+    public static final String PROPERTIES_FIELD = "properties";
+
+    @SerializedName(EVENT_TYPE_FIELD)
     public String eventTypeId;
+    @SerializedName(TRAFFIC_TYPE_NAME_FIELD)
     public String trafficTypeName;
+    @SerializedName(KEY_FIELD)
     public String key;
+    @SerializedName(VALUE_FIELD)
     public double value;
+    @SerializedName(TIMESTAMP_FIELD)
     public long timestamp;
+    @SerializedName(PROPERTIES_FIELD)
     public Map<String, Object> properties;
 
     @Override

--- a/src/main/java/io/split/android/client/utils/Json.java
+++ b/src/main/java/io/split/android/client/utils/Json.java
@@ -15,20 +15,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.split.android.client.utils.serializer.DoubleSerializer;
+
 public class Json {
 
     private static final Gson mJson = new GsonBuilder()
             .serializeNulls()
-            .registerTypeAdapter(Double.class, new JsonSerializer<Double>() {
-
-                // Send integers as such
-                @Override
-                public JsonElement serialize(Double src, Type typeOfSrc, JsonSerializationContext context) {
-                    if (src == src.longValue())
-                        return new JsonPrimitive(src.longValue());
-                    return new JsonPrimitive(src);
-                }
-            })
+            .registerTypeAdapter(Double.class, new DoubleSerializer())
             .create();
     private static volatile Gson mNonNullJson;
 
@@ -70,7 +63,9 @@ public class Json {
         if (mNonNullJson == null) {
             synchronized (Json.class) {
                 if (mNonNullJson == null) {
-                    mNonNullJson = new GsonBuilder().create();
+                    mNonNullJson = new GsonBuilder()
+                            .registerTypeAdapter(Double.class, new DoubleSerializer())
+                            .create();
                 }
             }
         }

--- a/src/main/java/io/split/android/client/utils/Json.java
+++ b/src/main/java/io/split/android/client/utils/Json.java
@@ -2,6 +2,10 @@ package io.split.android.client.utils;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
@@ -13,7 +17,19 @@ import java.util.Set;
 
 public class Json {
 
-    private static final Gson mJson = new GsonBuilder().serializeNulls().create();
+    private static final Gson mJson = new GsonBuilder()
+            .serializeNulls()
+            .registerTypeAdapter(Double.class, new JsonSerializer<Double>() {
+
+                // Send integers as such
+                @Override
+                public JsonElement serialize(Double src, Type typeOfSrc, JsonSerializationContext context) {
+                    if (src == src.longValue())
+                        return new JsonPrimitive(src.longValue());
+                    return new JsonPrimitive(src);
+                }
+            })
+            .create();
     private static volatile Gson mNonNullJson;
 
     public static String toJson(Object obj) {

--- a/src/main/java/io/split/android/client/utils/deserializer/EventDeserializer.java
+++ b/src/main/java/io/split/android/client/utils/deserializer/EventDeserializer.java
@@ -1,0 +1,76 @@
+package io.split.android.client.utils.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.split.android.client.dtos.Event;
+
+public class EventDeserializer implements JsonDeserializer<Event> {
+
+    @Override
+    public Event deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        JsonObject jsonObject = json.getAsJsonObject();
+        JsonObject properties = (!jsonObject.get(Event.PROPERTIES_FIELD).isJsonNull()) ? jsonObject.get(Event.PROPERTIES_FIELD).getAsJsonObject() : new JsonObject();
+
+        Event event = new Event();
+
+        if (jsonObject.get(Event.SIZE_IN_BYTES_FIELD) != null && !jsonObject.get(Event.SIZE_IN_BYTES_FIELD).isJsonNull()) {
+            event.setSizeInBytes(jsonObject.get(Event.SIZE_IN_BYTES_FIELD).getAsInt());
+        }
+        event.eventTypeId = jsonObject.get(Event.EVENT_TYPE_FIELD).getAsString();
+        event.trafficTypeName = jsonObject.get(Event.TRAFFIC_TYPE_NAME_FIELD).getAsString();
+        event.key = jsonObject.get(Event.KEY_FIELD).getAsString();
+        event.value = jsonObject.get(Event.VALUE_FIELD).getAsDouble();
+        event.timestamp = jsonObject.get(Event.TIMESTAMP_FIELD).getAsLong();
+        event.properties = buildMappedProperties(properties);
+
+        return event;
+    }
+
+    private static Map<String, Object> buildMappedProperties(JsonObject properties) {
+        Map<String, Object> mappedProperties = new HashMap<>();
+
+        if (properties == null) {
+            return Collections.unmodifiableMap(mappedProperties);
+        }
+
+        for (Map.Entry<String, JsonElement> prop : properties.entrySet()) {
+            JsonElement value = prop.getValue();
+            String key = prop.getKey();
+
+            if (value != null && !value.isJsonNull()) {
+                try {
+                    String valueAsString = value.getAsString();
+
+                    if (valueAsString.equals(String.valueOf(value.getAsBoolean()))) {
+                        mappedProperties.put(key, value.getAsBoolean());
+                    } else if (valueAsString.equals(String.valueOf(value.getAsInt()))) {
+                        mappedProperties.put(key, value.getAsInt());
+                    } else if (valueAsString.equals(String.valueOf(value.getAsLong()))) {
+                        mappedProperties.put(key, value.getAsLong());
+                    } else if (valueAsString.equals(String.valueOf(value.getAsDouble()))) {
+                        mappedProperties.put(key, value.getAsDouble());
+                    } else if (valueAsString.equals(String.valueOf(value.getAsBigDecimal()))) {
+                        mappedProperties.put(key, value.getAsBigDecimal());
+                    } else {
+                        mappedProperties.put(key, valueAsString);
+                    }
+                } catch (NumberFormatException numberFormatException) {
+                    mappedProperties.put(key, value.getAsString());
+                }
+            } else {
+                mappedProperties.put(key, "null");
+            }
+        }
+
+        return Collections.unmodifiableMap(mappedProperties);
+    }
+}

--- a/src/main/java/io/split/android/client/utils/deserializer/EventDeserializer.java
+++ b/src/main/java/io/split/android/client/utils/deserializer/EventDeserializer.java
@@ -67,7 +67,7 @@ public class EventDeserializer implements JsonDeserializer<Event> {
                     mappedProperties.put(key, value.getAsString());
                 }
             } else {
-                mappedProperties.put(key, "null");
+                mappedProperties.put(key, null);
             }
         }
 

--- a/src/main/java/io/split/android/client/utils/serializer/DoubleSerializer.java
+++ b/src/main/java/io/split/android/client/utils/serializer/DoubleSerializer.java
@@ -1,0 +1,18 @@
+package io.split.android.client.utils.serializer;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+
+public class DoubleSerializer implements JsonSerializer<Double> {
+
+    @Override
+    public JsonElement serialize(Double src, Type typeOfSrc, JsonSerializationContext context) {
+        if (src == src.longValue())
+            return new JsonPrimitive(src.longValue());
+        return new JsonPrimitive(src);
+    }
+}

--- a/src/test/java/io/split/android/client/service/events/EventsRequestBodySerializerTest.java
+++ b/src/test/java/io/split/android/client/service/events/EventsRequestBodySerializerTest.java
@@ -23,7 +23,7 @@ public class EventsRequestBodySerializerTest {
 
     @Test
     public void serialize() {
-        String expectedJson = "[{\"eventTypeId\":\"test\",\"trafficTypeName\":\"default\",\"key\":\"user_key\",\"value\":0.0,\"timestamp\":1645461035249,\"properties\":{\"test_prop_1\":\"test\",\"test_prop_2\":100.0,\"test_prop_3\":50.05}},{\"eventTypeId\":\"test\",\"trafficTypeName\":\"default\",\"key\":\"user_key\",\"value\":0.0,\"timestamp\":1645461036024,\"properties\":{\"test_prop_1\":\"test\",\"test_prop_2\":100.0,\"test_prop_3\":50.05}}]";
+        String expectedJson = "[{\"eventTypeId\":\"test\",\"trafficTypeName\":\"default\",\"key\":\"user_key\",\"value\":0,\"timestamp\":1645461035249,\"properties\":{\"test_prop_1\":\"test\",\"test_prop_2\":100,\"test_prop_3\":50.05}},{\"eventTypeId\":\"test\",\"trafficTypeName\":\"default\",\"key\":\"user_key\",\"value\":0,\"timestamp\":1645461036024,\"properties\":{\"test_prop_1\":\"test\",\"test_prop_2\":100,\"test_prop_3\":50.05}}]";
         Event event1 = new Event();
         event1.eventTypeId = "test";
         event1.key = "user_key";

--- a/src/test/java/io/split/android/client/utils/JsonTest.java
+++ b/src/test/java/io/split/android/client/utils/JsonTest.java
@@ -1,20 +1,20 @@
 package io.split.android.client.utils;
 
-import io.split.android.client.dtos.Partition;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import io.split.android.client.dtos.Partition;
 
 public class JsonTest {
+
     @Test
     public void unknownFieldsDontCauseProblems() {
 
         String json = "{\"treatment\":\"on\", \"size\":20, \"foo\":\"bar\"}";
         Partition partition = Json.fromJson(json, Partition.class);
 
-        assertThat(partition.treatment, is(equalTo("on")));
-        assertThat(partition.size, is(equalTo(20)));
+        assertEquals("on", partition.treatment);
+        assertEquals(20, partition.size);
     }
 }

--- a/src/test/java/io/split/android/client/utils/deserializer/EventDeserializerTest.java
+++ b/src/test/java/io/split/android/client/utils/deserializer/EventDeserializerTest.java
@@ -1,6 +1,7 @@
 package io.split.android.client.utils.deserializer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -23,7 +24,7 @@ public class EventDeserializerTest {
 
     @Test
     public void test() {
-        String source = "{\"sizeInBytes\":1024,\"eventTypeId\":\"type\",\"trafficTypeName\":\"user\",\"key\":\"CUSTOMER_ID\",\"value\":1.0,\"timestamp\":1648760271141,\"properties\":{\"decimal2\":20005579852.255556,\"string\":\"plain_string\",\"null\":\"null\",\"price\":24584535,\"decimal3\":20.45,\"true\":true,\"false\":false,\"id\":158576837,\"decimal\":20.000068,\"int\":4}}";
+        String source = "{\"sizeInBytes\":1024,\"eventTypeId\":\"type\",\"trafficTypeName\":\"user\",\"key\":\"CUSTOMER_ID\",\"value\":1.0,\"timestamp\":1648760271141,\"properties\":{\"decimal2\":20005579852.255556,\"string\":\"plain_string\",\"null\":null,\"price\":24584535,\"decimal3\":20.45,\"true\":true,\"false\":false,\"id\":158576837,\"decimal\":20.000068,\"int\":4}}";
 
         Gson gson = new GsonBuilder()
                 .registerTypeAdapter(Event.class, mDeserializer)
@@ -41,7 +42,7 @@ public class EventDeserializerTest {
         assertEquals(20.45, event.properties.get("decimal3"));
         assertEquals("plain_string", event.properties.get("string"));
         assertEquals(4, event.properties.get("int"));
-        assertEquals("null", event.properties.get("null"));
+        assertNull(event.properties.get("null"));
 
         String finalString = gson.toJson(event);
         assertEquals(source, finalString);

--- a/src/test/java/io/split/android/client/utils/deserializer/EventDeserializerTest.java
+++ b/src/test/java/io/split/android/client/utils/deserializer/EventDeserializerTest.java
@@ -1,0 +1,49 @@
+package io.split.android.client.utils.deserializer;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import io.split.android.client.dtos.Event;
+
+public class EventDeserializerTest {
+
+    private EventDeserializer mDeserializer;
+
+    @Before
+    public void setUp() {
+        mDeserializer = new EventDeserializer();
+    }
+
+    @Test
+    public void test() {
+        String source = "{\"sizeInBytes\":1024,\"eventTypeId\":\"type\",\"trafficTypeName\":\"user\",\"key\":\"CUSTOMER_ID\",\"value\":1.0,\"timestamp\":1648760271141,\"properties\":{\"decimal2\":20005579852.255556,\"string\":\"plain_string\",\"null\":\"null\",\"price\":24584535,\"decimal3\":20.45,\"true\":true,\"false\":false,\"id\":158576837,\"decimal\":20.000068,\"int\":4}}";
+
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapter(Event.class, mDeserializer)
+                .serializeNulls()
+                .create();
+
+        Event event = gson.fromJson(source, Event.class);
+        assertEquals(1024, event.getSizeInBytes());
+        assertEquals(24584535, event.properties.get("price"));
+        assertEquals(158576837, event.properties.get("id"));
+        assertEquals(true, event.properties.get("true"));
+        assertEquals(false, event.properties.get("false"));
+        assertEquals(20.000068, event.properties.get("decimal"));
+        assertEquals(new BigDecimal("20005579852.255556"), event.properties.get("decimal2"));
+        assertEquals(20.45, event.properties.get("decimal3"));
+        assertEquals("plain_string", event.properties.get("string"));
+        assertEquals(4, event.properties.get("int"));
+        assertEquals("null", event.properties.get("null"));
+
+        String finalString = gson.toJson(event);
+        assertEquals(source, finalString);
+    }
+}


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Added `Gson` deserializer for Events to prevent `Gson` from assuming a value is a `Double`, and expressing the value in scientific notation.
- Added `Gson` serializer for `Double` to prevent whole numbers to appear as fractions (i.e. `0` instead of `0.0`), matching the behavior to that of the Java SDK.