### PR TITLE
Avoid impression count with non existing previous time

### DIFF
--- a/src/androidTest/java/tests/integration/streaming/ImpressionsCountTest.java
+++ b/src/androidTest/java/tests/integration/streaming/ImpressionsCountTest.java
@@ -129,9 +129,9 @@ public class ImpressionsCountTest {
         Assert.assertTrue(client.isReady());
         Assert.assertEquals(3, mImpressions.size());
         Assert.assertEquals(3, mCounts.size());
-        Assert.assertEquals(10, c1.count);
-        Assert.assertEquals(20, c2.count);
-        Assert.assertEquals(40, c3.count);
+        Assert.assertEquals(9, c1.count);
+        Assert.assertEquals(19, c2.count);
+        Assert.assertEquals(39, c3.count);
 
         splitFactory.destroy();
     }

--- a/src/main/java/io/split/android/client/service/impressions/ImpressionManagerImpl.java
+++ b/src/main/java/io/split/android/client/service/impressions/ImpressionManagerImpl.java
@@ -91,7 +91,7 @@ public class ImpressionManagerImpl implements ImpressionManager {
     public void pushImpression(Impression impression) {
         Long previousTime = mImpressionsObserver.testAndSet(impression);
         impression = impression.withPreviousTime(previousTime);
-        if (shouldTrackImpressionsCount() && (previousTime != null && previousTime != 0)) {
+        if (shouldTrackImpressionsCount() && previousTimeIsValid(previousTime)) {
             mImpressionsCounter.inc(impression.split(), impression.time(), 1);
         }
 
@@ -225,5 +225,9 @@ public class ImpressionManagerImpl implements ImpressionManager {
 
     private boolean shouldTrackImpressionsCount() {
         return isOptimizedImpressionsMode() || isNoneImpressionsMode();
+    }
+
+    private static boolean previousTimeIsValid(Long previousTime) {
+        return previousTime != null && previousTime != 0;
     }
 }

--- a/src/main/java/io/split/android/client/service/impressions/ImpressionManagerImpl.java
+++ b/src/main/java/io/split/android/client/service/impressions/ImpressionManagerImpl.java
@@ -49,6 +49,7 @@ public class ImpressionManagerImpl implements ImpressionManager {
                 taskExecutor,
                 splitTaskFactory,
                 telemetryRuntimeProducer,
+                new ImpressionsCounter(),
                 uniqueKeysTracker,
                 impressionManagerConfig,
                 new RecorderSyncHelperImpl<>(
@@ -67,6 +68,7 @@ public class ImpressionManagerImpl implements ImpressionManager {
     public ImpressionManagerImpl(@NonNull SplitTaskExecutor taskExecutor,
                                  @NonNull ImpressionsTaskFactory splitTaskFactory,
                                  @NonNull TelemetryRuntimeProducer telemetryRuntimeProducer,
+                                 @NonNull ImpressionsCounter impressionsCounter,
                                  @NonNull UniqueKeysTracker uniqueKeysTracker,
                                  @NonNull ImpressionManagerConfig impressionManagerConfig,
                                  @NonNull RecorderSyncHelper<KeyImpression> impressionsSyncHelper,
@@ -77,7 +79,7 @@ public class ImpressionManagerImpl implements ImpressionManager {
         mImpressionManagerConfig = checkNotNull(impressionManagerConfig);
 
         mImpressionsObserver = new ImpressionsObserver(ServiceConstants.LAST_SEEN_IMPRESSION_CACHE_SIZE);
-        mImpressionsCounter = new ImpressionsCounter();
+        mImpressionsCounter = checkNotNull(impressionsCounter);
         mUniqueKeysTracker = checkNotNull(uniqueKeysTracker);
 
         mImpressionsSyncHelper = checkNotNull(impressionsSyncHelper);
@@ -87,9 +89,9 @@ public class ImpressionManagerImpl implements ImpressionManager {
 
     @Override
     public void pushImpression(Impression impression) {
-        impression = impression.withPreviousTime(mImpressionsObserver.testAndSet(impression));
-        KeyImpression keyImpression = KeyImpression.fromImpression(impression);
-        if (shouldTrackImpressionsCount()) {
+        Long previousTime = mImpressionsObserver.testAndSet(impression);
+        impression = impression.withPreviousTime(previousTime);
+        if (shouldTrackImpressionsCount() && (previousTime != null && previousTime != 0)) {
             mImpressionsCounter.inc(impression.split(), impression.time(), 1);
         }
 
@@ -101,6 +103,7 @@ public class ImpressionManagerImpl implements ImpressionManager {
             }
         }
 
+        KeyImpression keyImpression = KeyImpression.fromImpression(impression);
         if (!shouldTrackImpressionsCount() || (!isNoneImpressionsMode() && shouldPushImpression(keyImpression))) {
             if (mImpressionsSyncHelper.pushAndCheckIfFlushNeeded(keyImpression)) {
                 mTaskExecutor.submit(

--- a/src/main/java/io/split/android/client/service/impressions/ImpressionManagerImpl.java
+++ b/src/main/java/io/split/android/client/service/impressions/ImpressionManagerImpl.java
@@ -63,7 +63,6 @@ public class ImpressionManagerImpl implements ImpressionManager {
                         ServiceConstants.UNIQUE_KEYS_MAX_RETRY_ATTEMPTS));
     }
 
-
     @VisibleForTesting
     public ImpressionManagerImpl(@NonNull SplitTaskExecutor taskExecutor,
                                  @NonNull ImpressionsTaskFactory splitTaskFactory,

--- a/src/main/java/io/split/android/client/service/impressions/ImpressionsObserver.java
+++ b/src/main/java/io/split/android/client/service/impressions/ImpressionsObserver.java
@@ -1,9 +1,9 @@
 package io.split.android.client.service.impressions;
 
+import androidx.annotation.Nullable;
+
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-
-import java.util.Objects;
 
 import io.split.android.client.impressions.Impression;
 
@@ -17,7 +17,8 @@ public class ImpressionsObserver {
                 .concurrencyLevel(4)  // Just setting the default value explicitly
                 .build();
     }
-    
+
+    @Nullable
     public Long testAndSet(Impression impression) {
         if (null == impression) {
             return null;

--- a/src/test/java/io/split/android/client/service/ImpressionsObserverTest.java
+++ b/src/test/java/io/split/android/client/service/ImpressionsObserverTest.java
@@ -1,5 +1,7 @@
 package io.split.android.client.service;
 
+import static org.junit.Assert.assertNull;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -48,7 +50,7 @@ public class ImpressionsObserverTest {
         for (Impression i : generateImpressions(5)) {
             observer.testAndSet(i);
         }
-        Assert.assertNull(observer.testAndSet(imp));
+        assertNull(observer.testAndSet(imp));
         Assert.assertEquals(observer.testAndSet(imp).longValue(), imp.time());
     }
 
@@ -63,14 +65,33 @@ public class ImpressionsObserverTest {
         Thread t5 = new Thread(() -> caller(observer, 1000, imps));
 
         // start the 5 threads an wait for them to finish.
-        t1.setDaemon(true); t2.setDaemon(true); t3.setDaemon(true); t4.setDaemon(true); t5.setDaemon(true);
-        t1.start(); t2.start(); t3.start(); t4.start(); t5.start();
-        t1.join(); t2.join(); t3.join(); t4.join(); t5.join();
+        t1.setDaemon(true);
+        t2.setDaemon(true);
+        t3.setDaemon(true);
+        t4.setDaemon(true);
+        t5.setDaemon(true);
+        t1.start();
+        t2.start();
+        t3.start();
+        t4.start();
+        t5.start();
+        t1.join();
+        t2.join();
+        t3.join();
+        t4.join();
+        t5.join();
 
         Assert.assertEquals(imps.size(), 5000);
         for (Impression i : imps) {
             Assert.assertTrue(i.previousTime() == null || i.previousTime() <= i.time());
         }
+    }
+
+    @Test
+    public void testAndSetWithNullImpressionReturnsNullPreviousTime() {
+        ImpressionsObserver observer = new ImpressionsObserver(1);
+
+        assertNull(observer.testAndSet(null));
     }
 
     private void caller(ImpressionsObserver o, int count, ConcurrentLinkedQueue<Impression> imps) {

--- a/src/test/java/io/split/android/client/service/ImpressionsObserverTest.java
+++ b/src/test/java/io/split/android/client/service/ImpressionsObserverTest.java
@@ -17,7 +17,6 @@ public class ImpressionsObserverTest {
 
     // We allow the cache implementation to have a 0.01% drift in size when elements change, given that it's internal
     // structure/references might vary, and the ObjectSizeCalculator is not 100% accurate
-    private static final double SIZE_DELTA = 0.01;
     private final Random mRandom = new Random();
 
     private List<Impression> generateImpressions(long count) {

--- a/src/test/java/io/split/android/client/service/impressions/ImpressionManagerImplTest.java
+++ b/src/test/java/io/split/android/client/service/impressions/ImpressionManagerImplTest.java
@@ -65,8 +65,6 @@ public class ImpressionManagerImplTest {
     @Mock
     private RetryBackoffCounterTimer mUniqueKeysCounterTimer;
 
-    private ImpressionManagerConfig mConfig;
-
     @Before
     public void setUp() {
         MockitoAnnotations.openMocks(this);
@@ -78,7 +76,7 @@ public class ImpressionManagerImplTest {
         when(mTaskFactory.createSaveUniqueImpressionsTask(any())).thenReturn(mock(SaveUniqueImpressionsTask.class));
         when(mTaskFactory.createUniqueImpressionsRecorderTask()).thenReturn(mock(UniqueKeysRecorderTask.class));
 
-        mConfig = new ImpressionManagerConfig(
+        ImpressionManagerConfig mConfig = new ImpressionManagerConfig(
                 1800,
                 1800,
                 ImpressionManagerConfig.Mode.OPTIMIZED,

--- a/src/test/java/io/split/android/client/service/impressions/ImpressionManagerImplTest.java
+++ b/src/test/java/io/split/android/client/service/impressions/ImpressionManagerImplTest.java
@@ -324,14 +324,7 @@ public class ImpressionManagerImplTest {
     @Test
     public void pushImpressionRecordsInTelemetry() {
 
-        mImpressionsManager.pushImpression(new Impression("key",
-                "key",
-                "split",
-                "treatment",
-                10000,
-                "rule",
-                25L,
-                Collections.emptyMap()));
+        pushDummyImpression(mImpressionsManager);
 
         verify(mTelemetryRuntimeProducer).recordImpressionStats(ImpressionsDataType.IMPRESSIONS_QUEUED, 1);
     }
@@ -339,29 +332,9 @@ public class ImpressionManagerImplTest {
     @Test
     public void countIsNotIncrementedWhenPreviousTimeDoesNotExist() {
 
-        mImpressionsManager = new ImpressionManagerImpl(mTaskExecutor,
-                mTaskFactory,
-                mTelemetryRuntimeProducer,
-                mImpressionsCounter,
-                mUniqueKeysTracker,
-                new ImpressionManagerConfig(
-                        1800,
-                        1800,
-                        ImpressionManagerConfig.Mode.OPTIMIZED,
-                        3,
-                        2048,
-                        500
-                ),
-                mRecorderSyncHelper, mUniqueKeysCounterTimer);
+        mImpressionsManager = getOptimizedModeManager();
 
-        mImpressionsManager.pushImpression(new Impression("key",
-                "key",
-                "split",
-                "treatment",
-                10000,
-                "rule",
-                25L,
-                Collections.emptyMap()));
+        pushDummyImpression(mImpressionsManager);
 
         verifyNoInteractions(mImpressionsCounter);
     }
@@ -369,31 +342,11 @@ public class ImpressionManagerImplTest {
     @Test
     public void countIsIncrementedWhenPreviousTimeExists() {
 
-        mImpressionsManager = new ImpressionManagerImpl(mTaskExecutor,
-                mTaskFactory,
-                mTelemetryRuntimeProducer,
-                mImpressionsCounter,
-                mUniqueKeysTracker,
-                new ImpressionManagerConfig(
-                        1800,
-                        1800,
-                        ImpressionManagerConfig.Mode.OPTIMIZED,
-                        3,
-                        2048,
-                        500
-                ),
-                mRecorderSyncHelper, mUniqueKeysCounterTimer);
+        mImpressionsManager = getOptimizedModeManager();
 
         int impressionsToPush = 3;
         for (int i = 0; i < impressionsToPush; i++) {
-            mImpressionsManager.pushImpression(new Impression("key",
-                    "key",
-                    "split",
-                    "treatment",
-                    10000,
-                    "rule",
-                    25L,
-                    Collections.emptyMap()));
+            pushDummyImpression(mImpressionsManager);
         }
 
         verify(mImpressionsCounter, times(impressionsToPush - 1)).inc("split", 10000, 1);
@@ -435,5 +388,34 @@ public class ImpressionManagerImplTest {
                         2048,
                         500
                 ));
+    }
+
+    @NonNull
+    private ImpressionManagerImpl getOptimizedModeManager() {
+        return new ImpressionManagerImpl(mTaskExecutor,
+                mTaskFactory,
+                mTelemetryRuntimeProducer,
+                mImpressionsCounter,
+                mUniqueKeysTracker,
+                new ImpressionManagerConfig(
+                        1800,
+                        1800,
+                        ImpressionManagerConfig.Mode.OPTIMIZED,
+                        3,
+                        2048,
+                        500
+                ),
+                mRecorderSyncHelper, mUniqueKeysCounterTimer);
+    }
+
+    private static void pushDummyImpression(ImpressionManager impressionsManager) {
+        impressionsManager.pushImpression(new Impression("key",
+                "key",
+                "split",
+                "treatment",
+                10000,
+                "rule",
+                25L,
+                Collections.emptyMap()));
     }
 }


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Prevent impression count to be increased if calculated previous time is null or 0.