### PR TITLE
Policy for task executor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ ext {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 30
     targetCompatibility = '1.8'
     sourceCompatibility = '1.8'
 
@@ -90,7 +90,7 @@ dependencies {
     def annotationVersion = '1.2.0'
     def gsonVersion = '2.8.9'
     def guavaVersion = '31.0.1-android'
-    def snakeYamlVersion = '1.32'
+    def snakeYamlVersion = '1.29'
     def jetBrainsAnnotationsVersion = '22.0.0'
     def okHttpVersion = '3.12.0'
     def playServicesVersion = '17.6.0'

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     def annotationVersion = '1.2.0'
     def gsonVersion = '2.8.9'
     def guavaVersion = '31.0.1-android'
-    def snakeYamlVersion = '1.29'
+    def snakeYamlVersion = '1.32'
     def jetBrainsAnnotationsVersion = '22.0.0'
     def okHttpVersion = '3.12.0'
     def playServicesVersion = '17.6.0'

--- a/build.gradle
+++ b/build.gradle
@@ -9,18 +9,16 @@ buildscript {
     }
 }
 
-plugins {
-    id 'com.android.library'
-    id 'maven-publish'
-    id 'signing'
-}
+apply plugin: 'com.android.library'
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 ext {
     splitVersion = '2.12.2'
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     targetCompatibility = '1.8'
     sourceCompatibility = '1.8'
 
@@ -77,6 +75,11 @@ android {
             buildConfigField("String", "SPLIT_VERSION_NAME", "\"${splitVersion}\"")
         }
     }
+}
+
+repositories {
+    google()
+    mavenCentral()
 }
 
 dependencies {

--- a/src/androidTest/java/tests/integration/SingleSyncTest.java
+++ b/src/androidTest/java/tests/integration/SingleSyncTest.java
@@ -11,6 +11,7 @@ import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -181,42 +182,42 @@ public class SingleSyncTest {
         client.destroy();
     }
 
-    /// TODO: Uncomment when impressions mode NONE available
-//    @Test
-//    public void singleSyncEnabledImpressionsNone() throws Exception {
-//        SplitFactory factory = buildFactory(ImpressionsMode.OPTIMIZED);
-//        SplitClient client = factory.client();
-//
-//        CountDownLatch readyLatch = new CountDownLatch(1);
-//        SplitEventTaskHelper readyTask = new SplitEventTaskHelper(readyLatch);
-//        SplitEventTaskHelper readyTimeOutTask = new SplitEventTaskHelper(readyLatch);
-//
-//        client.on(SplitEvent.SDK_READY, readyTask);
-//        client.on(SplitEvent.SDK_READY_TIMED_OUT, readyTimeOutTask);
-//
-//        readyLatch.await(5, TimeUnit.SECONDS);
-//
-//        generateData(factory, client);
-//
-//        mKeyLatch = new CountDownLatch(1);
-//        mEveLatch = new CountDownLatch(1);
-//        mImpCountLatch = new CountDownLatch(1);
-//
-//        simulateBgFg(); // Make the SDK to store impressions count
-//
-//        mKeyLatch.await(5, TimeUnit.SECONDS);
-//        mEveLatch.await(5, TimeUnit.SECONDS);
-//        mImpCountLatch.await(5, TimeUnit.SECONDS);
-//
-//        Assert.assertEquals(1, mSplitsHitCount);
-//        Assert.assertEquals(4, mMySegmentsHitCount); // One for key
-//        Assert.assertEquals(0, mSseAuthHitCount);
-//        Assert.assertTrue(mEventsHitCount > 3);
-//        Assert.assertTrue(mUniqueKeysHitCount > 3);
-//        Assert.assertTrue(mImpressionsCountHitCount > 0);
-//
-//        client.destroy();
-//    }
+    @Ignore("Ignored until impressions mode NONE is available")
+    @Test
+    public void singleSyncEnabledImpressionsNone() throws Exception {
+        SplitFactory factory = buildFactory(ImpressionsMode.OPTIMIZED);
+        SplitClient client = factory.client();
+
+        CountDownLatch readyLatch = new CountDownLatch(1);
+        SplitEventTaskHelper readyTask = new SplitEventTaskHelper(readyLatch);
+        SplitEventTaskHelper readyTimeOutTask = new SplitEventTaskHelper(readyLatch);
+
+        client.on(SplitEvent.SDK_READY, readyTask);
+        client.on(SplitEvent.SDK_READY_TIMED_OUT, readyTimeOutTask);
+
+        readyLatch.await(5, TimeUnit.SECONDS);
+
+        generateData(factory, client);
+
+        mKeyLatch = new CountDownLatch(1);
+        mEveLatch = new CountDownLatch(1);
+        mImpCountLatch = new CountDownLatch(1);
+
+        simulateBgFg(); // Make the SDK to store impressions count
+
+        mKeyLatch.await(5, TimeUnit.SECONDS);
+        mEveLatch.await(5, TimeUnit.SECONDS);
+        mImpCountLatch.await(5, TimeUnit.SECONDS);
+
+        Assert.assertEquals(1, mSplitsHitCount);
+        Assert.assertEquals(4, mMySegmentsHitCount); // One for key
+        Assert.assertEquals(0, mSseAuthHitCount);
+        Assert.assertTrue(mEventsHitCount > 3);
+        Assert.assertTrue(mUniqueKeysHitCount > 3);
+        Assert.assertTrue(mImpressionsCountHitCount > 0);
+
+        client.destroy();
+    }
 
     void simulateBgFg() {
         mLifecycleManager.simulateOnPause();

--- a/src/main/java/io/split/android/client/SplitClientConfig.java
+++ b/src/main/java/io/split/android/client/SplitClientConfig.java
@@ -949,13 +949,27 @@ public class SplitClientConfig {
         }
 
         /**
-         * Period in minutes to execute background synchronization
-         * Default values is 15 minutes and is the minimum allowed.
-         * Is a lower value is especified default value will be used.
+         * Period in minutes to execute background synchronization.
+         * Default value is 15 minutes and is the minimum allowed.
+         * If a lower value is specified, the default value will be used.
+         *
+         * @return this builder
+         *
+         * @deprecated Use {@link #synchronizeInBackgroundPeriod(long backgroundSyncPeriod)}
+         */
+        @Deprecated
+        public Builder sychronizeInBackgroundPeriod(long backgroundSyncPeriod) {
+            return synchronizeInBackgroundPeriod(backgroundSyncPeriod);
+        }
+
+        /**
+         * Period in minutes to execute background synchronization.
+         * Default value is 15 minutes and is the minimum allowed.
+         * If a lower value is specified, the default value will be used.
          *
          * @return this builder
          */
-        public Builder sychronizeInBackgroundPeriod(long backgroundSyncPeriod) {
+        public Builder synchronizeInBackgroundPeriod(long backgroundSyncPeriod) {
             _backgroundSyncPeriod = backgroundSyncPeriod;
             return this;
         }

--- a/src/main/java/io/split/android/client/SplitClientConfig.java
+++ b/src/main/java/io/split/android/client/SplitClientConfig.java
@@ -954,22 +954,8 @@ public class SplitClientConfig {
          * If a lower value is specified, the default value will be used.
          *
          * @return this builder
-         *
-         * @deprecated Use {@link #synchronizeInBackgroundPeriod(long backgroundSyncPeriod)}
          */
-        @Deprecated
         public Builder sychronizeInBackgroundPeriod(long backgroundSyncPeriod) {
-            return synchronizeInBackgroundPeriod(backgroundSyncPeriod);
-        }
-
-        /**
-         * Period in minutes to execute background synchronization.
-         * Default value is 15 minutes and is the minimum allowed.
-         * If a lower value is specified, the default value will be used.
-         *
-         * @return this builder
-         */
-        public Builder synchronizeInBackgroundPeriod(long backgroundSyncPeriod) {
             _backgroundSyncPeriod = backgroundSyncPeriod;
             return this;
         }

--- a/src/main/java/io/split/android/client/lifecycle/SplitLifecycleManagerImpl.java
+++ b/src/main/java/io/split/android/client/lifecycle/SplitLifecycleManagerImpl.java
@@ -11,8 +11,6 @@ import java.util.List;
 
 import io.split.android.client.service.synchronizer.ThreadUtils;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 public class SplitLifecycleManagerImpl implements LifecycleObserver, SplitLifecycleManager {
 
     private final List<WeakReference<SplitLifecycleAware>> mComponents;

--- a/src/main/java/io/split/android/client/service/executor/SplitTaskExecutorImpl.java
+++ b/src/main/java/io/split/android/client/service/executor/SplitTaskExecutorImpl.java
@@ -6,12 +6,9 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import io.split.android.engine.scheduler.PausableScheduledThreadPoolExecutorImpl;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
 public class SplitTaskExecutorImpl extends SplitBaseTaskExecutor {
 
-    private static final int MIN_THREADPOOL_SIZE_WHEN_IDLE = 6;
+    private static final int MIN_THREAD_POOL_SIZE_WHEN_IDLE = 6;
     private static final String THREAD_NAME_FORMAT = "split-taskExecutor-%d";
 
     @NonNull
@@ -20,6 +17,6 @@ public class SplitTaskExecutorImpl extends SplitBaseTaskExecutor {
         ThreadFactoryBuilder threadFactoryBuilder = new ThreadFactoryBuilder();
         threadFactoryBuilder.setDaemon(true);
         threadFactoryBuilder.setNameFormat(THREAD_NAME_FORMAT);
-        return new PausableScheduledThreadPoolExecutorImpl(MIN_THREADPOOL_SIZE_WHEN_IDLE, threadFactoryBuilder.build());
+        return new PausableScheduledThreadPoolExecutorImpl(MIN_THREAD_POOL_SIZE_WHEN_IDLE, threadFactoryBuilder.build());
     }
 }

--- a/src/main/java/io/split/android/client/service/synchronizer/WorkManagerWrapper.java
+++ b/src/main/java/io/split/android/client/service/synchronizer/WorkManagerWrapper.java
@@ -70,6 +70,7 @@ public class WorkManagerWrapper implements MySegmentsWorkManagerWrapper {
         mWorkManager.cancelUniqueWork(SplitTaskType.MY_SEGMENTS_SYNC.toString());
         mWorkManager.cancelUniqueWork(SplitTaskType.EVENTS_RECORDER.toString());
         mWorkManager.cancelUniqueWork(SplitTaskType.IMPRESSIONS_RECORDER.toString());
+        mWorkManager.cancelUniqueWork(SplitTaskType.UNIQUE_KEYS_RECORDER_TASK.toString());
         if (mFetcherExecutionListener != null) {
             mFetcherExecutionListener.clear();
         }
@@ -125,7 +126,7 @@ public class WorkManagerWrapper implements MySegmentsWorkManagerWrapper {
 
                                 for (WorkInfo workInfo : workInfoList) {
                                     Logger.d("Work manager task: " + workInfo.getTags() +
-                                            ", state: " + workInfo.getState().toString());
+                                            ", state: " + workInfo.getState());
                                     updateTaskStatus(workInfo);
                                 }
                             }
@@ -159,14 +160,14 @@ public class WorkManagerWrapper implements MySegmentsWorkManagerWrapper {
         }
         boolean shouldLoadLocal = mShouldLoadFromLocal.contains(taskType.toString());
         if (!shouldLoadLocal) {
-            Logger.d("Avoiding update for " + taskType.toString());
+            Logger.d("Avoiding update for " + taskType);
             mShouldLoadFromLocal.add(taskType.toString());
             return;
         }
 
         SplitTaskExecutionListener listener = mFetcherExecutionListener.get();
         if (listener != null) {
-            Logger.d("Updating for " + taskType.toString());
+            Logger.d("Updating for " + taskType);
             listener.taskExecuted(SplitTaskExecutionInfo.success(taskType));
         }
     }

--- a/src/main/java/io/split/android/client/storage/db/impressions/unique/UniqueKeyEntity.java
+++ b/src/main/java/io/split/android/client/storage/db/impressions/unique/UniqueKeyEntity.java
@@ -78,7 +78,7 @@ public class UniqueKeyEntity implements Identifiable {
         return id;
     }
 
-    public void setId(int id) {
+    public void setId(long id) {
         this.id = id;
     }
 }

--- a/src/main/java/io/split/android/engine/scheduler/PausableScheduledThreadPoolExecutorImpl.java
+++ b/src/main/java/io/split/android/engine/scheduler/PausableScheduledThreadPoolExecutorImpl.java
@@ -2,13 +2,14 @@ package io.split.android.engine.scheduler;
 
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class PausableScheduledThreadPoolExecutorImpl extends ScheduledThreadPoolExecutor implements PausableScheduledThreadPoolExecutor {
     private boolean isPaused;
-    private ReentrantLock pauseLock = new ReentrantLock();
-    private Condition unpaused = pauseLock.newCondition();
+    private final ReentrantLock pauseLock = new ReentrantLock();
+    private final Condition unpaused = pauseLock.newCondition();
     private final static int POOL_SIZE = 1;
 
     public static PausableScheduledThreadPoolExecutor newSingleThreadScheduledExecutor(ThreadFactory threadFactory) {
@@ -17,9 +18,10 @@ public class PausableScheduledThreadPoolExecutorImpl extends ScheduledThreadPool
 
     public PausableScheduledThreadPoolExecutorImpl(int corePoolSize,
                                                     ThreadFactory threadFactory) {
-        super(corePoolSize, threadFactory);
+        super(corePoolSize, threadFactory, new ThreadPoolExecutor.DiscardPolicy());
     }
 
+    @Override
     protected void beforeExecute(Thread thread, Runnable task) {
         super.beforeExecute(thread, task);
         pauseLock.lock();

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">android-client</string>
-</resources>

--- a/src/test/java/io/split/android/client/service/synchronizer/WorkManagerWrapperTest.java
+++ b/src/test/java/io/split/android/client/service/synchronizer/WorkManagerWrapperTest.java
@@ -52,7 +52,7 @@ public class WorkManagerWrapperTest {
                                 .telemetryServiceEndpoint("https://test.split.io/telemetry")
                                 .build()
                 )
-                .synchronizeInBackgroundPeriod(5263)
+                .sychronizeInBackgroundPeriod(5263)
                 .eventsPerPush(526)
                 .impressionsPerPush(256)
                 .backgroundSyncWhenWifiOnly(true)

--- a/src/test/java/io/split/android/client/service/synchronizer/WorkManagerWrapperTest.java
+++ b/src/test/java/io/split/android/client/service/synchronizer/WorkManagerWrapperTest.java
@@ -52,7 +52,7 @@ public class WorkManagerWrapperTest {
                                 .telemetryServiceEndpoint("https://test.split.io/telemetry")
                                 .build()
                 )
-                .sychronizeInBackgroundPeriod(5263)
+                .synchronizeInBackgroundPeriod(5263)
                 .eventsPerPush(526)
                 .impressionsPerPush(256)
                 .backgroundSyncWhenWifiOnly(true)

--- a/src/test/java/io/split/android/engine/scheduler/PausableScheduledThreadPoolExecutorImplTest.java
+++ b/src/test/java/io/split/android/engine/scheduler/PausableScheduledThreadPoolExecutorImplTest.java
@@ -1,0 +1,86 @@
+package io.split.android.engine.scheduler;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+public class PausableScheduledThreadPoolExecutorImplTest {
+
+    private PausableScheduledThreadPoolExecutor executor;
+
+    @Before
+    public void setUp() {
+        executor = PausableScheduledThreadPoolExecutorImpl.newSingleThreadScheduledExecutor(Executors.defaultThreadFactory());
+    }
+
+    @After
+    public void tearDown() {
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void rejectedExecutionExceptionIsNotThrownWhenSubmittingTaskAfterShutdown() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final CountDownLatch latch2 = new CountDownLatch(2);
+        boolean exceptionThrown = false;
+        Runnable testTask = latch::countDown;
+        Runnable testTask2 = latch2::countDown;
+
+        executor.submit(testTask);
+        boolean taskIsExecuted = latch.await(2L, TimeUnit.SECONDS);
+
+        executor.shutdownNow();
+        try {
+            executor.submit(testTask2);
+        } catch (RejectedExecutionException exception) {
+            exceptionThrown = true;
+        }
+        boolean task2IsExecuted = latch2.await(2L, TimeUnit.SECONDS);
+
+        assertTrue(taskIsExecuted);
+        assertFalse(task2IsExecuted);
+        assertFalse(exceptionThrown);
+    }
+
+    @Test
+    public void pausingWorksCorrectly() throws InterruptedException {
+        final CountDownLatch timerLatch = new CountDownLatch(1);
+        final CountDownLatch latch = new CountDownLatch(4);
+
+        Runnable testTask = latch::countDown;
+
+        executor.scheduleAtFixedRate(testTask, 0L, 10L, TimeUnit.MILLISECONDS);
+        timerLatch.await(20L, TimeUnit.MILLISECONDS);
+        executor.pause();
+
+        boolean taskCompleted = latch.await(50L, TimeUnit.MILLISECONDS);
+
+        assertFalse(taskCompleted);
+    }
+
+    @Test
+    public void resumingWorksCorrectly() throws InterruptedException {
+        final CountDownLatch timerLatch = new CountDownLatch(1);
+        final CountDownLatch latch = new CountDownLatch(4);
+
+        Runnable testTask = latch::countDown;
+
+        executor.scheduleAtFixedRate(testTask, 0L, 10L, TimeUnit.MILLISECONDS);
+        timerLatch.await(20L, TimeUnit.MILLISECONDS);
+        executor.pause();
+        timerLatch.await(20L, TimeUnit.MILLISECONDS);
+
+        executor.resume();
+        boolean taskCompleted = latch.await(50L, TimeUnit.MILLISECONDS);
+
+        assertTrue(taskCompleted);
+    }
+}


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Added a policy in the pausable task executor to prevent exceptions from being raised if tasks are submitted after the executor has been shut down.
- Added additional tests. 