### PR TITLE
None strategy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ dependencies {
     def playServicesVersion = '17.6.0'
 
     def jUnitVersion = '4.13.2'
-    def mockitoVersion = '3.12.4'
+    def mockitoVersion = '4.8.0'
     def hamcrestVersion = '1.3'
     def apacheCommonsVersion = '3.12.0'
     def kotlinVer = '1.5.31'
@@ -132,8 +132,6 @@ dependencies {
     testImplementation "org.hamcrest:hamcrest-all:$hamcrestVersion"
     testImplementation "org.apache.commons:commons-lang3:$apacheCommonsVersion"
     testImplementation "com.squareup.okhttp3:mockwebserver:$mockWebServerVersion"
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVer"
-    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVer"
 
     androidTestImplementation "androidx.test:core:$androidTestVersion"
     androidTestImplementation "androidx.test:runner:$androidTestVersion"
@@ -141,8 +139,6 @@ dependencies {
     androidTestImplementation "com.squareup.okhttp3:mockwebserver:$mockWebServerVersion"
     androidTestImplementation "androidx.room:room-testing:$roomVersion"
     androidTestImplementation "androidx.work:work-testing:$workVersion"
-    androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVer"
-    androidTestImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVer"
 }
 
 afterEvaluate {

--- a/src/main/java/io/split/android/client/service/impressions/ImpressionManagerImpl.java
+++ b/src/main/java/io/split/android/client/service/impressions/ImpressionManagerImpl.java
@@ -90,7 +90,7 @@ public class ImpressionManagerImpl implements ImpressionManager {
         if (isNoneImpressionsMode()) {
             mUniqueKeysTracker.track(impression.key(), impression.split());
 
-            if (mUniqueKeysTracker.size() >= ServiceConstants.MAX_UNIQUE_KEYS_IN_MEMORY) {
+            if (mUniqueKeysTracker.isFull()) {
                 saveUniqueKeys();
             }
         }

--- a/src/main/java/io/split/android/client/service/impressions/strategy/NoneStrategy.java
+++ b/src/main/java/io/split/android/client/service/impressions/strategy/NoneStrategy.java
@@ -16,7 +16,7 @@ import io.split.android.client.service.impressions.ImpressionsTaskFactory;
 import io.split.android.client.service.impressions.unique.UniqueKeysTracker;
 
 /**
- * {@link ProcessStrategy} that corresponds to NONE {@link ImpressionsMode}
+ * {@link ProcessStrategy} that corresponds to NONE Impressions mode.
  */
 class NoneStrategy implements ProcessStrategy {
 

--- a/src/main/java/io/split/android/client/service/impressions/strategy/NoneStrategy.java
+++ b/src/main/java/io/split/android/client/service/impressions/strategy/NoneStrategy.java
@@ -41,9 +41,7 @@ class NoneStrategy implements ProcessStrategy {
     }
 
     @Override
-    public void apply(@NonNull List<Impression> impressions) {
-        Impression impression = impressions.get(0); //TODO
-
+    public void apply(@NonNull Impression impression) {
         Long previousTime = mImpressionsObserver.testAndSet(impression);
         impression = impression.withPreviousTime(previousTime);
         if (previousTimeIsValid(previousTime)) {

--- a/src/main/java/io/split/android/client/service/impressions/strategy/NoneStrategy.java
+++ b/src/main/java/io/split/android/client/service/impressions/strategy/NoneStrategy.java
@@ -1,0 +1,68 @@
+package io.split.android.client.service.impressions.strategy;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import androidx.annotation.NonNull;
+
+import java.util.List;
+
+import io.split.android.client.impressions.Impression;
+import io.split.android.client.service.ServiceConstants;
+import io.split.android.client.service.executor.SplitTaskExecutor;
+import io.split.android.client.service.impressions.ImpressionsCounter;
+import io.split.android.client.service.impressions.ImpressionsMode;
+import io.split.android.client.service.impressions.ImpressionsObserver;
+import io.split.android.client.service.impressions.ImpressionsTaskFactory;
+import io.split.android.client.service.impressions.unique.UniqueKeysTracker;
+
+/**
+ * {@link ProcessStrategy} that corresponds to NONE {@link ImpressionsMode}
+ */
+class NoneStrategy implements ProcessStrategy {
+
+    private final ImpressionsObserver mImpressionsObserver;
+    private final SplitTaskExecutor mTaskExecutor;
+    private final ImpressionsTaskFactory mTaskFactory;
+
+    private final ImpressionsCounter mImpressionsCounter;
+    private final UniqueKeysTracker mUniqueKeysTracker;
+
+    public NoneStrategy(@NonNull ImpressionsObserver impressionsObserver,
+                        @NonNull SplitTaskExecutor taskExecutor,
+                        @NonNull ImpressionsTaskFactory taskFactory,
+                        @NonNull ImpressionsCounter impressionsCounter,
+                        @NonNull UniqueKeysTracker uniqueKeysTracker) {
+        mImpressionsObserver = checkNotNull(impressionsObserver);
+        mTaskExecutor = checkNotNull(taskExecutor);
+        mTaskFactory = checkNotNull(taskFactory);
+
+        mImpressionsCounter = checkNotNull(impressionsCounter);
+        mUniqueKeysTracker = checkNotNull(uniqueKeysTracker);
+    }
+
+    @Override
+    public void apply(@NonNull List<Impression> impressions) {
+        Impression impression = impressions.get(0); //TODO
+
+        Long previousTime = mImpressionsObserver.testAndSet(impression);
+        impression = impression.withPreviousTime(previousTime);
+        if (previousTimeIsValid(previousTime)) {
+            mImpressionsCounter.inc(impression.split(), impression.time(), 1);
+        }
+
+        mUniqueKeysTracker.track(impression.key(), impression.split());
+
+        if (mUniqueKeysTracker.size() >= ServiceConstants.MAX_UNIQUE_KEYS_IN_MEMORY) {
+            saveUniqueKeys();
+        }
+    }
+
+    private static boolean previousTimeIsValid(Long previousTime) {
+        return previousTime != null && previousTime != 0;
+    }
+
+    private void saveUniqueKeys() {
+        mTaskExecutor.submit(
+                mTaskFactory.createSaveUniqueImpressionsTask(mUniqueKeysTracker.popAll()), null);
+    }
+}

--- a/src/main/java/io/split/android/client/service/impressions/strategy/ProcessStrategy.java
+++ b/src/main/java/io/split/android/client/service/impressions/strategy/ProcessStrategy.java
@@ -1,0 +1,10 @@
+package io.split.android.client.service.impressions.strategy;
+
+import java.util.List;
+
+import io.split.android.client.impressions.Impression;
+
+public interface ProcessStrategy {
+
+    void apply(List<Impression> impressions);
+}

--- a/src/main/java/io/split/android/client/service/impressions/strategy/ProcessStrategy.java
+++ b/src/main/java/io/split/android/client/service/impressions/strategy/ProcessStrategy.java
@@ -1,10 +1,10 @@
 package io.split.android.client.service.impressions.strategy;
 
-import java.util.List;
+import androidx.annotation.NonNull;
 
 import io.split.android.client.impressions.Impression;
 
 public interface ProcessStrategy {
 
-    void apply(List<Impression> impressions);
+    void apply(@NonNull Impression impression);
 }

--- a/src/main/java/io/split/android/client/service/impressions/unique/UniqueKeysTracker.java
+++ b/src/main/java/io/split/android/client/service/impressions/unique/UniqueKeysTracker.java
@@ -9,5 +9,5 @@ public interface UniqueKeysTracker {
 
     Map<String, Set<String>> popAll();
 
-    int size();
+    boolean isFull();
 }

--- a/src/main/java/io/split/android/client/service/impressions/unique/UniqueKeysTrackerImpl.java
+++ b/src/main/java/io/split/android/client/service/impressions/unique/UniqueKeysTrackerImpl.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.split.android.client.service.ServiceConstants;
+
 public class UniqueKeysTrackerImpl implements UniqueKeysTracker {
 
     private final Map<String, Set<String>> mCache;
@@ -43,7 +45,7 @@ public class UniqueKeysTrackerImpl implements UniqueKeysTracker {
     }
 
     @Override
-    public int size() {
-        return mCache.size();
+    public boolean isFull() {
+        return mCache.size() >= ServiceConstants.MAX_UNIQUE_KEYS_IN_MEMORY;
     }
 }

--- a/src/test/java/io/split/android/client/service/impressions/ImpressionManagerImplTest.java
+++ b/src/test/java/io/split/android/client/service/impressions/ImpressionManagerImplTest.java
@@ -165,6 +165,7 @@ public class ImpressionManagerImplTest {
                 any(SplitTaskExecutionListener.class));
     }
 
+    // TODO remove
     @Test
     public void pushImpressionWithNoneModeSavesKeysWhenCacheSizeIsExceeded() {
         when(mUniqueKeysTracker.size()).thenReturn(30000);
@@ -374,6 +375,7 @@ public class ImpressionManagerImplTest {
         verify(mTelemetryRuntimeProducer).recordImpressionStats(ImpressionsDataType.IMPRESSIONS_QUEUED, 1);
     }
 
+    // TODO remove
     @Test
     public void countIsNotIncrementedWhenPreviousTimeDoesNotExist() {
 
@@ -384,6 +386,7 @@ public class ImpressionManagerImplTest {
         verifyNoInteractions(mImpressionsCounter);
     }
 
+    //TODO remove
     @Test
     public void countIsIncrementedWhenPreviousTimeExists() {
 

--- a/src/test/java/io/split/android/client/service/impressions/ImpressionManagerImplTest.java
+++ b/src/test/java/io/split/android/client/service/impressions/ImpressionManagerImplTest.java
@@ -165,18 +165,6 @@ public class ImpressionManagerImplTest {
                 any(SplitTaskExecutionListener.class));
     }
 
-    // TODO remove
-    @Test
-    public void pushImpressionWithNoneModeSavesKeysWhenCacheSizeIsExceeded() {
-        when(mUniqueKeysTracker.size()).thenReturn(30000);
-
-        mImpressionsManager = getNoneModeManager();
-
-        mImpressionsManager.pushImpression(createUniqueImpression());
-
-        verify(mTaskExecutor).submit(any(SaveUniqueImpressionsTask.class), eq(null));
-    }
-
     @Test
     public void flushWithOptimizedMode() {
         RetryBackoffCounterTimer impressionsTimer = mock(RetryBackoffCounterTimer.class);

--- a/src/test/java/io/split/android/client/service/impressions/ImpressionManagerRetryTimerProviderImplTest.kt
+++ b/src/test/java/io/split/android/client/service/impressions/ImpressionManagerRetryTimerProviderImplTest.kt
@@ -1,11 +1,11 @@
 package io.split.android.client.service.impressions
 
 import io.split.android.client.service.executor.SplitTaskExecutor
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
-import kotlin.test.assertEquals
 
 class ImpressionManagerRetryTimerProviderImplTest {
 

--- a/src/test/java/io/split/android/client/service/impressions/strategy/NoneStrategyTest.kt
+++ b/src/test/java/io/split/android/client/service/impressions/strategy/NoneStrategyTest.kt
@@ -54,7 +54,7 @@ class NoneStrategyTest {
         val uniqueImpressionsTask = mock(SaveUniqueImpressionsTask::class.java)
         `when`(taskFactory.createSaveUniqueImpressionsTask(any())).thenReturn(uniqueImpressionsTask)
 
-        strategy.apply(listOf(createUniqueImpression()))
+        strategy.apply(createUniqueImpression())
 
         verify(taskExecutor).submit(
             eq(uniqueImpressionsTask),
@@ -65,14 +65,14 @@ class NoneStrategyTest {
     @Test
     fun `impression is tracked by unique keys tracker`() {
         with(createUniqueImpression()) {
-            strategy.apply(listOf(this))
+            strategy.apply(this)
             verify(uniqueKeysTracker).track(key(), split())
         }
     }
 
     @Test
     fun `count is not incremented when previous time does not exist`() {
-        strategy.apply(listOf(createUniqueImpression()))
+        strategy.apply(createUniqueImpression())
 
         verifyNoInteractions(impressionsCounter)
     }
@@ -83,8 +83,8 @@ class NoneStrategyTest {
             .thenReturn(null)
             .thenReturn(100L)
 
-        strategy.apply(listOf(createUniqueImpression(split = "split")))
-        strategy.apply(listOf(createUniqueImpression(split = "split")))
+        strategy.apply(createUniqueImpression(split = "split"))
+        strategy.apply(createUniqueImpression(split = "split"))
 
         verify(impressionsCounter, times(1)).inc(
             "split",

--- a/src/test/java/io/split/android/client/service/impressions/strategy/NoneStrategyTest.kt
+++ b/src/test/java/io/split/android/client/service/impressions/strategy/NoneStrategyTest.kt
@@ -1,0 +1,107 @@
+package io.split.android.client.service.impressions.strategy
+
+import io.split.android.client.impressions.Impression
+import io.split.android.client.service.executor.SplitTaskExecutionListener
+import io.split.android.client.service.executor.SplitTaskExecutor
+import io.split.android.client.service.impressions.ImpressionsCounter
+import io.split.android.client.service.impressions.ImpressionsObserver
+import io.split.android.client.service.impressions.ImpressionsTaskFactory
+import io.split.android.client.service.impressions.unique.SaveUniqueImpressionsTask
+import io.split.android.client.service.impressions.unique.UniqueKeysTracker
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.MockitoAnnotations
+import java.util.*
+
+class NoneStrategyTest {
+
+    @Mock
+    private lateinit var impressionsObserver: ImpressionsObserver
+
+    @Mock
+    private lateinit var taskExecutor: SplitTaskExecutor
+
+    @Mock
+    private lateinit var taskFactory: ImpressionsTaskFactory
+
+    @Mock
+    private lateinit var impressionsCounter: ImpressionsCounter
+
+    @Mock
+    private lateinit var uniqueKeysTracker: UniqueKeysTracker
+
+    private lateinit var strategy: NoneStrategy
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        strategy = NoneStrategy(
+            impressionsObserver,
+            taskExecutor,
+            taskFactory,
+            impressionsCounter,
+            uniqueKeysTracker
+        )
+    }
+
+    @Test
+    fun `keys are flushed when cache size is exceeded`() {
+        `when`(uniqueKeysTracker.size()).thenReturn(30000)
+        val uniqueImpressionsTask = mock(SaveUniqueImpressionsTask::class.java)
+        `when`(taskFactory.createSaveUniqueImpressionsTask(any())).thenReturn(uniqueImpressionsTask)
+
+        strategy.apply(listOf(createUniqueImpression()))
+
+        verify(taskExecutor).submit(
+            eq(uniqueImpressionsTask),
+            eq<SplitTaskExecutionListener?>(null)
+        )
+    }
+
+    @Test
+    fun `impression is tracked by unique keys tracker`() {
+        with(createUniqueImpression()) {
+            strategy.apply(listOf(this))
+            verify(uniqueKeysTracker).track(key(), split())
+        }
+    }
+
+    @Test
+    fun `count is not incremented when previous time does not exist`() {
+        strategy.apply(listOf(createUniqueImpression()))
+
+        verifyNoInteractions(impressionsCounter)
+    }
+
+    @Test
+    fun `count is incremented when previous time exists`() {
+        `when`(impressionsObserver.testAndSet(any()))
+            .thenReturn(null)
+            .thenReturn(100L)
+
+        strategy.apply(listOf(createUniqueImpression(split = "split")))
+        strategy.apply(listOf(createUniqueImpression(split = "split")))
+
+        verify(impressionsCounter, times(1)).inc(
+            "split",
+            100,
+            1
+        )
+    }
+}
+
+private fun createUniqueImpression(split: String = UUID.randomUUID().toString()): Impression =
+    Impression(
+        "key",
+        "bkey",
+        split,
+        "on",
+        100L,
+        "default rule",
+        999L,
+        null
+    )


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Added `ProcessStrategy` interface. The `apply` method receives only one `Impression` since it's what makes the most sense in this SDK.
- Created the `NoneStrategy`.