### PR TITLE
Config class cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ android {
         targetSdkVersion 30
         versionCode 0
         versionName splitVersion
-        multiDexEnabled true
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'split-proguard-rules.pro'
@@ -98,7 +97,6 @@ dependencies {
     def jetBrainsAnnotationsVersion = '22.0.0'
     def okHttpVersion = '3.12.13'
     def playServicesVersion = '17.6.0'
-    def multidexVersion = '1.0.3'
 
     def jUnitVersion = '4.13.2'
     def mockitoVersion = '3.12.4'
@@ -127,7 +125,6 @@ dependencies {
     implementation "org.jetbrains:annotations:$jetBrainsAnnotationsVersion"
     implementation "com.squareup.okhttp3:okhttp:$okHttpVersion"
     implementation "com.google.android.gms:play-services-base:$playServicesVersion"
-    implementation "com.android.support:multidex:$multidexVersion"
 
     // Test
     testImplementation "junit:junit:$jUnitVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ android {
         targetSdkVersion 30
         versionCode 0
         versionName splitVersion
+        multiDexEnabled true
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'split-proguard-rules.pro'
@@ -97,6 +98,7 @@ dependencies {
     def jetBrainsAnnotationsVersion = '22.0.0'
     def okHttpVersion = '3.12.13'
     def playServicesVersion = '17.6.0'
+    def multidexVersion = '1.0.3'
 
     def jUnitVersion = '4.13.2'
     def mockitoVersion = '3.12.4'
@@ -125,6 +127,7 @@ dependencies {
     implementation "org.jetbrains:annotations:$jetBrainsAnnotationsVersion"
     implementation "com.squareup.okhttp3:okhttp:$okHttpVersion"
     implementation "com.google.android.gms:play-services-base:$playServicesVersion"
+    implementation "com.android.support:multidex:$multidexVersion"
 
     // Test
     testImplementation "junit:junit:$jUnitVersion"

--- a/src/androidTest/java/helper/IntegrationHelper.java
+++ b/src/androidTest/java/helper/IntegrationHelper.java
@@ -35,6 +35,7 @@ import io.split.android.client.storage.db.SplitRoomDatabase;
 import io.split.android.client.telemetry.storage.TelemetryStorage;
 import io.split.android.client.utils.logger.Logger;
 import io.split.android.client.utils.NetworkHelper;
+import io.split.android.client.utils.logger.SplitLogLevel;
 import io.split.sharedtest.fake.HttpStreamResponseMock;
 
 public class IntegrationHelper {
@@ -175,7 +176,7 @@ public class IntegrationHelper {
         return SplitClientConfig.builder()
                 .ready(30000)
                 .streamingEnabled(true)
-                .enableDebug()
+                .logLevel(SplitLogLevel.DEBUG)
                 .trafficType("account")
                 .build();
     }

--- a/src/androidTest/java/helper/TestableSplitConfigBuilder.java
+++ b/src/androidTest/java/helper/TestableSplitConfigBuilder.java
@@ -22,15 +22,11 @@ public class TestableSplitConfigBuilder {
     private long mImpressionsChunkSize = 2 * 1024;
     private int mImpressionsPerPush = 10;
     private int mImpressionsCountersRefreshRate = 1800;
-    private int mMetricsRefreshRate = 1800;
     private int mConnectionTimeout = 15000;
     private int mReadTimeout = 15000;
-    private int mNumThreadsForSegmentFetch = 2;
     private int mReady = -1;
-    private boolean mDebugEnabled = false;
     private boolean mLabelsEnabled = true;
     private ImpressionListener mImpressionListener;
-    private int mWaitBeforeShutdown = 5000;
     private String mHostname;
     private String mIp;
     private String mProxy = null;
@@ -49,8 +45,6 @@ public class TestableSplitConfigBuilder {
     private boolean mShouldRecordTelemetry = false;
 
     private boolean mStreamingEnabled = true;
-    private int mAuthRetryBackoffBase = 1;
-    private int mStreamingReconnectBackoffBase = 1;
     private DevelopmentSslConfig mDevelopmentSslConfig = null;
     private ImpressionsMode mImpressionsMode = ImpressionsMode.OPTIMIZED;
     private SyncConfig mSyncConfig = SyncConfig.builder().build();
@@ -89,11 +83,6 @@ public class TestableSplitConfigBuilder {
         return this;
     }
 
-    public TestableSplitConfigBuilder metricsRefreshRate(int metricsRefreshRate) {
-        this.mMetricsRefreshRate = metricsRefreshRate;
-        return this;
-    }
-
     public TestableSplitConfigBuilder connectionTimeout(int connectionTimeout) {
         this.mConnectionTimeout = connectionTimeout;
         return this;
@@ -104,18 +93,12 @@ public class TestableSplitConfigBuilder {
         return this;
     }
 
-    public TestableSplitConfigBuilder numThreadsForSegmentFetch(int numThreadsForSegmentFetch) {
-        this.mNumThreadsForSegmentFetch = numThreadsForSegmentFetch;
-        return this;
-    }
-
     public TestableSplitConfigBuilder ready(int ready) {
         this.mReady = ready;
         return this;
     }
 
     public TestableSplitConfigBuilder enableDebug() {
-        this.mDebugEnabled = true;
         return this;
     }
 
@@ -126,11 +109,6 @@ public class TestableSplitConfigBuilder {
 
     public TestableSplitConfigBuilder impressionListener(ImpressionListener impressionListener) {
         this.mImpressionListener = impressionListener;
-        return this;
-    }
-
-    public TestableSplitConfigBuilder waitBeforeShutdown(int waitBeforeShutdown) {
-        this.mWaitBeforeShutdown = waitBeforeShutdown;
         return this;
     }
 
@@ -176,16 +154,6 @@ public class TestableSplitConfigBuilder {
 
     public TestableSplitConfigBuilder streamingEnabled(boolean streamingEnabled) {
         mStreamingEnabled = streamingEnabled;
-        return this;
-    }
-
-    public TestableSplitConfigBuilder authRetryBackoffBase(int authRetryBackoffBase) {
-        mAuthRetryBackoffBase = authRetryBackoffBase;
-        return this;
-    }
-
-    public TestableSplitConfigBuilder streamingReconnectBackoffBase(int streamingReconnectBackoffBase) {
-        mStreamingReconnectBackoffBase = streamingReconnectBackoffBase;
         return this;
     }
 
@@ -268,15 +236,11 @@ public class TestableSplitConfigBuilder {
                     mImpressionsQueueSize,
                     mImpressionsChunkSize,
                     mImpressionsPerPush,
-                    mMetricsRefreshRate,
                     mConnectionTimeout,
                     mReadTimeout,
-                    mNumThreadsForSegmentFetch,
                     mReady,
-                    mDebugEnabled,
                     mLabelsEnabled,
                     mImpressionListener,
-                    mWaitBeforeShutdown,
                     mHostname,
                     mIp,
                     mProxy,
@@ -290,8 +254,6 @@ public class TestableSplitConfigBuilder {
                     mBackgroundSyncWhenBatteryNotLow,
                     mBackgroundSyncWhenWifiOnly,
                     mStreamingEnabled,
-                    mAuthRetryBackoffBase,
-                    mStreamingReconnectBackoffBase,
                     mServiceEndpoints.getAuthServiceEndpoint(),
                     mServiceEndpoints.getStreamingServiceEndpoint(),
                     mDevelopmentSslConfig,

--- a/src/androidTest/java/tests/integration/InitialChangeNumberTest.java
+++ b/src/androidTest/java/tests/integration/InitialChangeNumberTest.java
@@ -26,6 +26,7 @@ import io.split.android.client.api.Key;
 import io.split.android.client.events.SplitEvent;
 import io.split.android.client.storage.db.GeneralInfoEntity;
 import io.split.android.client.storage.db.SplitRoomDatabase;
+import io.split.android.client.utils.logger.SplitLogLevel;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -112,7 +113,7 @@ public class InitialChangeNumberTest {
                 .segmentsRefreshRate(30)
                 .impressionsRefreshRate(99999)
                 .streamingEnabled(false)
-                .enableDebug()
+                .logLevel(SplitLogLevel.DEBUG)
                 .build();
 
 

--- a/src/androidTest/java/tests/integration/IntegrationTest.java
+++ b/src/androidTest/java/tests/integration/IntegrationTest.java
@@ -47,6 +47,7 @@ import io.split.android.client.storage.db.GeneralInfoEntity;
 import io.split.android.client.storage.db.SplitEntity;
 import io.split.android.client.storage.db.SplitRoomDatabase;
 import io.split.android.client.utils.Json;
+import io.split.android.client.utils.logger.SplitLogLevel;
 import io.split.android.grammar.Treatments;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
@@ -130,7 +131,7 @@ public class IntegrationTest {
                 .segmentsRefreshRate(30)
                 .impressionsRefreshRate(30)
                 .eventFlushInterval(200)
-                .enableDebug()
+                .logLevel(SplitLogLevel.DEBUG)
                 .trafficType("account")
                 .eventsPerPush(10)
                 .eventsQueueSize(100)
@@ -264,7 +265,7 @@ public class IntegrationTest {
                 .featuresRefreshRate(30)
                 .segmentsRefreshRate(30)
                 .impressionsRefreshRate(30)
-                .enableDebug()
+                .logLevel(SplitLogLevel.DEBUG)
                 .trafficType("account")
                 .eventsPerPush(10)
                 .eventsQueueSize(100)

--- a/src/androidTest/java/tests/integration/SplitFetchSpecificSplitTest.java
+++ b/src/androidTest/java/tests/integration/SplitFetchSpecificSplitTest.java
@@ -38,6 +38,7 @@ import io.split.android.client.events.SplitEvent;
 import io.split.android.client.storage.db.GeneralInfoEntity;
 import io.split.android.client.storage.db.SplitRoomDatabase;
 import io.split.android.client.utils.logger.Logger;
+import io.split.android.client.utils.logger.SplitLogLevel;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -127,7 +128,7 @@ public class SplitFetchSpecificSplitTest {
                 .impressionsRefreshRate(99999999)
                 .eventFlushInterval(9999999)
                 .syncConfig(syncConfig)
-                .enableDebug()
+                .logLevel(SplitLogLevel.DEBUG)
                 .trafficType("account")
                 .eventsPerPush(10)
                 .eventsQueueSize(100)

--- a/src/androidTest/java/tests/integration/shared/BaseSharedClientsTest.java
+++ b/src/androidTest/java/tests/integration/shared/BaseSharedClientsTest.java
@@ -15,6 +15,7 @@ import io.split.android.client.SplitClientConfig;
 import io.split.android.client.SplitFactory;
 import io.split.android.client.api.Key;
 import io.split.android.client.storage.db.SplitRoomDatabase;
+import io.split.android.client.utils.logger.SplitLogLevel;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockWebServer;
 
@@ -56,7 +57,7 @@ abstract class BaseSharedClientsTest {
                 .serviceEndpoints(ServiceEndpoints.builder()
                         .apiEndpoint(serverUrl).eventsEndpoint(serverUrl).build())
                 .ready(30000)
-                .enableDebug()
+                .logLevel(SplitLogLevel.DEBUG)
                 .featuresRefreshRate(99999)
                 .segmentsRefreshRate(99999)
                 .impressionsRefreshRate(99999)

--- a/src/androidTest/java/tests/integration/shared/SharedClientsIntegrationTest.java
+++ b/src/androidTest/java/tests/integration/shared/SharedClientsIntegrationTest.java
@@ -35,6 +35,7 @@ import io.split.android.client.storage.db.GeneralInfoEntity;
 import io.split.android.client.storage.db.SplitEntity;
 import io.split.android.client.storage.db.SplitRoomDatabase;
 import io.split.android.client.utils.Json;
+import io.split.android.client.utils.logger.SplitLogLevel;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -73,7 +74,7 @@ public class SharedClientsIntegrationTest {
                         .serviceEndpoints(ServiceEndpoints.builder()
                                 .apiEndpoint(serverUrl).eventsEndpoint(serverUrl).build())
                         .ready(30000)
-                        .enableDebug()
+                        .logLevel(SplitLogLevel.DEBUG)
                         .featuresRefreshRate(99999)
                         .segmentsRefreshRate(99999)
                         .impressionsRefreshRate(99999)
@@ -130,8 +131,8 @@ public class SharedClientsIntegrationTest {
             }
         });
 
-        boolean await = readyLatch.await(5, TimeUnit.SECONDS);
-        boolean await2 = readyLatch2.await(5, TimeUnit.SECONDS);
+        boolean await = readyLatch.await(10, TimeUnit.SECONDS);
+        boolean await2 = readyLatch2.await(10, TimeUnit.SECONDS);
 
         assertTrue(await);
         assertTrue(await2);
@@ -225,8 +226,8 @@ public class SharedClientsIntegrationTest {
             }
         });
 
-        boolean await = readyLatch.await(5, TimeUnit.SECONDS);
-        boolean await2 = readyLatch2.await(5, TimeUnit.SECONDS);
+        boolean await = readyLatch.await(10, TimeUnit.SECONDS);
+        boolean await2 = readyLatch2.await(10, TimeUnit.SECONDS);
 
         assertTrue(await);
         assertTrue(await2);

--- a/src/androidTest/java/tests/integration/streaming/CleanUpDatabaseTest.java
+++ b/src/androidTest/java/tests/integration/streaming/CleanUpDatabaseTest.java
@@ -43,6 +43,7 @@ import io.split.android.client.storage.db.StorageRecordStatus;
 import io.split.android.client.utils.logger.Logger;
 import io.split.android.client.storage.db.impressions.unique.UniqueKeyEntity;
 import io.split.android.client.storage.db.impressions.unique.UniqueKeysDao;
+import io.split.android.client.utils.logger.SplitLogLevel;
 import io.split.sharedtest.fake.HttpStreamResponseMock;
 
 import static java.lang.Thread.sleep;
@@ -126,7 +127,7 @@ public class CleanUpDatabaseTest {
                 .streamingEnabled(true)
                 .impressionsRefreshRate(999999999)
                 .eventFlushInterval(99999999)
-                .enableDebug()
+                .logLevel(SplitLogLevel.DEBUG)
                 .trafficType("account")
                 .build();
 

--- a/src/androidTest/java/tests/integration/streaming/SseAuthFail4xxTest.java
+++ b/src/androidTest/java/tests/integration/streaming/SseAuthFail4xxTest.java
@@ -71,12 +71,12 @@ public class SseAuthFail4xxTest {
 
         client.on(SplitEvent.SDK_READY, readyTask);
 
-        latch.await(40, TimeUnit.SECONDS);
+        boolean await = latch.await(40, TimeUnit.SECONDS);
         mSseAuthLatch.await(40, TimeUnit.SECONDS);
         mMySegmentsHitsCountLatch.await(40, TimeUnit.SECONDS);
         mSplitsHitsCountLatch.await(40, TimeUnit.SECONDS);
 
-        Assert.assertTrue(readyTask.isOnPostExecutionCalled);
+        Assert.assertTrue(await);
         Assert.assertTrue(mIsStreamingAuth);
         Assert.assertTrue(client.isReady());
         Assert.assertTrue(splitFactory.isReady());

--- a/src/androidTest/java/tests/service/EventsRequestTest.java
+++ b/src/androidTest/java/tests/service/EventsRequestTest.java
@@ -56,7 +56,7 @@ public class EventsRequestTest {
         SplitClient client = mSplitFactory.client();
 
         client.track("test_event");
-        Thread.sleep(500);
+        Thread.sleep(1000);
         client.destroy();
         boolean await = mEventsLatch.await(10, TimeUnit.SECONDS);
 

--- a/src/androidTest/java/tests/service/UniqueKeysIntegrationTest.java
+++ b/src/androidTest/java/tests/service/UniqueKeysIntegrationTest.java
@@ -34,6 +34,7 @@ import io.split.android.client.service.impressions.ImpressionsMode;
 import io.split.android.client.storage.db.SplitRoomDatabase;
 import io.split.android.client.storage.db.impressions.unique.UniqueKeyEntity;
 import io.split.android.client.utils.logger.Logger;
+import io.split.android.client.utils.logger.SplitLogLevel;
 import tests.integration.shared.TestingHelper;
 
 public class UniqueKeysIntegrationTest {
@@ -199,7 +200,7 @@ public class UniqueKeysIntegrationTest {
                 new SplitClientConfig.Builder()
                         .ready(30000)
                         .streamingEnabled(true)
-                        .enableDebug()
+                        .logLevel(SplitLogLevel.DEBUG)
                         .trafficType("account")
                         .build(),
                 mContext,

--- a/src/main/java/io/split/android/client/SplitClientConfig.java
+++ b/src/main/java/io/split/android/client/SplitClientConfig.java
@@ -29,12 +29,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class SplitClientConfig {
 
-    // TODO: Refactor this huge class
-
     private static final int MIN_FEATURES_REFRESH_RATE = 30;
     private static final int MIN_MYSEGMENTS_REFRESH_RATE = 30;
     private static final int MIN_IMPRESSIONS_REFRESH_RATE = 30;
-    private static final int MIN_METRICS_REFRESH_RATE = 30;
     private static final int MIN_IMPRESSIONS_QUEUE_SIZE = 0;
     private static final int MIN_IMPRESSIONS_CHUNK_SIZE = 0;
     private static final int MIN_CONNECTION_TIMEOUT = 0;
@@ -47,23 +44,13 @@ public class SplitClientConfig {
     private static final int DEFAULT_IMP_COUNTERS_REFRESH_RATE_SECS = 1800;
     private static final int DEFAULT_CONNECTION_TIMEOUT_SECS = 15000;
     private static final int DEFAULT_READ_TIMEOUT_SECS = 15000;
-    private static final int DEFAULT_NUM_THREAD_FOR_SEGMENT_FETCH = 2;
     private static final int DEFAULT_READY = -1;
-    private static final int DEFAULT_METRICS_REFRESH_RATE_SECS = 1800;
-    private static final int DEFAULT_WAIT_BEFORE_SHUTDOW_SECS = 5000;
     private static final int DEFAULT_IMPRESSIONS_CHUNK_SIZE = 2 * 1024;
     private static final int DEFAULT_EVENTS_QUEUE_SIZE = 10000;
     private static final int DEFAULT_EVENTS_FLUSH_INTERVAL = 1800;
     private static final int DEFAULT_EVENTS_PER_PUSH = 2000;
     private static final int DEFAULT_BACKGROUND_SYNC_PERIOD_MINUTES = 15;
 
-    private static final int DEFAULT_AUTH_RETRY_BACKOFF_BASE_SECS = 1;
-    private static final int DEFAULT_STREAMING_RECONNECT_BACKOFF_BASE_SECS = 1;
-
-    private static final int IMPRESSIONS_MAX_SENT_ATTEMPTS = 3;
-    private static final int IMPRESSIONS_CHUNK_OUTDATED_TIME = 3600 * 1000; // One day millis
-    private final static int EVENTS_MAX_SENT_ATTEMPS = 3;
-    private final static int MAX_QUEUE_SIZE_IN_BYTES = 5242880; // 5mb
     private final static int DEFAULT_MTK_PER_PUSH = 30000;
 
     // Validation settings
@@ -75,42 +62,35 @@ public class SplitClientConfig {
 
     private static final long SPLITS_CACHE_EXPIRATION_IN_SECONDS = ServiceConstants.DEFAULT_SPLITS_CACHE_EXPIRATION_IN_SECONDS; // 10 días
 
-    private String _endpoint;
-    private String _eventsEndpoint;
-    private String _telemetryEndpoint;
-    private static String _hostname;
-    private static String _ip;
-
-    private HttpProxy _proxy = null;
-    private Authenticator _proxyAuthenticator = null;
+    private final String _endpoint;
+    private final String _eventsEndpoint;
+    private final String _telemetryEndpoint;
+    private final String _hostname;
+    private final String _ip;
+    private final HttpProxy _proxy;
+    private final Authenticator _proxyAuthenticator;
 
     private final int _featuresRefreshRate;
     private final int _segmentsRefreshRate;
     private final int _impressionsRefreshRate;
     private final int _impressionsQueueSize;
     private final int _impressionsPerPush;
-    private final static int _impressionsMaxSentAttempts = IMPRESSIONS_MAX_SENT_ATTEMPTS;
-    private final static long _impressionsChunkOudatedTime = IMPRESSIONS_CHUNK_OUTDATED_TIME;
     private final int _impCountersRefreshRate;
     private final int _mtkPerPush;
     private final int _mtkRefreshRate;
 
-    private final int _metricsRefreshRate;
     private final int _connectionTimeout;
     private final int _readTimeout;
-    private final int _numThreadsForSegmentFetch;
-    private final boolean _debugEnabled;
     private final boolean _labelsEnabled;
     private final int _ready;
     private final ImpressionListener _impressionListener;
-    private final int _waitBeforeShutdown;
-    private long _impressionsChunkSize;
+    private final long _impressionsChunkSize;
 
     // Background sync
-    private boolean _synchronizeInBackground;
-    private long _backgroundSyncPeriod;
-    private boolean _backgroundSyncWhenBatteryNotLow;
-    private boolean _backgroundSyncWhenWifiOnly;
+    private final boolean _synchronizeInBackground;
+    private final long _backgroundSyncPeriod;
+    private final boolean _backgroundSyncWhenBatteryNotLow;
+    private final boolean _backgroundSyncWhenWifiOnly;
 
     //.Track configuration
     private final int _eventsQueueSize;
@@ -119,17 +99,15 @@ public class SplitClientConfig {
     private final String _trafficType;
 
     // Push notification settings
-    private boolean _streamingEnabled;
-    private int _authRetryBackoffBase;
-    private int _streamingReconnectBackoffBase;
-    private String _authServiceUrl;
-    private String _streamingServiceUrl;
-    private DevelopmentSslConfig _developmentSslConfig;
+    private final boolean _streamingEnabled;
+    private final String _authServiceUrl;
+    private final String _streamingServiceUrl;
+    private final DevelopmentSslConfig _developmentSslConfig;
 
-    private SyncConfig _syncConfig;
+    private final SyncConfig _syncConfig;
 
-    private boolean _legacyStorageMigrationEnabled;
-    private ImpressionsMode _impressionsMode;
+    private final boolean _legacyStorageMigrationEnabled;
+    private final ImpressionsMode _impressionsMode;
     private final boolean _isPersistentAttributesEnabled;
     private final int _offlineRefreshRate;
     private boolean _shouldRecordTelemetry;
@@ -144,24 +122,19 @@ public class SplitClientConfig {
         return new Builder();
     }
 
-
     private SplitClientConfig(String endpoint,
                               String eventsEndpoint,
-                              int pollForFeatureChangesEveryNSeconds,
+                              int featureRefreshRate,
                               int segmentsRefreshRate,
                               int impressionsRefreshRate,
                               int impressionsQueueSize,
                               long impressionsChunkSize,
                               int impressionsPerPush,
-                              int metricsRefreshRate,
                               int connectionTimeout,
                               int readTimeout,
-                              int numThreadsForSegmentFetch,
                               int ready,
-                              boolean debugEnabled,
                               boolean labelsEnabled,
                               ImpressionListener impressionListener,
-                              int waitBeforeShutdown,
                               String hostname,
                               String ip,
                               HttpProxy proxy,
@@ -175,8 +148,6 @@ public class SplitClientConfig {
                               boolean backgroundSyncWhenBatteryNotLow,
                               boolean backgroundSyncWhenWifiOnly,
                               boolean streamingEnabled,
-                              int authRetryBackoffBase,
-                              int streamingReconnectBackoffBase,
                               String authServiceUrl,
                               String streamingServiceUrl,
                               DevelopmentSslConfig developmentSslConfig,
@@ -196,22 +167,18 @@ public class SplitClientConfig {
         _endpoint = endpoint;
         _eventsEndpoint = eventsEndpoint;
         _telemetryEndpoint = telemetryEndpoint;
-        _featuresRefreshRate = pollForFeatureChangesEveryNSeconds;
+        _featuresRefreshRate = featureRefreshRate;
         _segmentsRefreshRate = segmentsRefreshRate;
         _impressionsRefreshRate = impressionsRefreshRate;
         _impressionsQueueSize = impressionsQueueSize;
         _impressionsPerPush = impressionsPerPush;
         _impCountersRefreshRate = impCountersRefreshRate;
         _mtkRefreshRate = mtkRefreshRate;
-        _metricsRefreshRate = metricsRefreshRate;
         _connectionTimeout = connectionTimeout;
         _readTimeout = readTimeout;
-        _numThreadsForSegmentFetch = numThreadsForSegmentFetch;
         _ready = ready;
-        _debugEnabled = debugEnabled;
         _labelsEnabled = labelsEnabled;
         _impressionListener = impressionListener;
-        _waitBeforeShutdown = waitBeforeShutdown;
         _impressionsChunkSize = impressionsChunkSize;
         _hostname = hostname;
         _ip = ip;
@@ -228,8 +195,6 @@ public class SplitClientConfig {
         _backgroundSyncWhenBatteryNotLow = backgroundSyncWhenBatteryNotLow;
         _backgroundSyncWhenWifiOnly = backgroundSyncWhenWifiOnly;
         _streamingEnabled = streamingEnabled;
-        _authRetryBackoffBase = authRetryBackoffBase;
-        _streamingReconnectBackoffBase = streamingReconnectBackoffBase;
         _authServiceUrl = authServiceUrl;
         _streamingServiceUrl = streamingServiceUrl;
         _developmentSslConfig = developmentSslConfig;
@@ -246,24 +211,9 @@ public class SplitClientConfig {
 
         _shouldRecordTelemetry = shouldRecordTelemetry;
 
-        if (_debugEnabled && _logLevel == SplitLogLevel.NONE) {
-            _logLevel = SplitLogLevel.DEBUG;
-        }
-
         _mtkPerPush = mtkPerPush;
 
         Logger.instance().setLevel(_logLevel);
-    }
-
-    private static boolean isTestMode() {
-        boolean result;
-        try {
-            Class.forName("io.split.android.client.SplitClientConfigTest");
-            result = true;
-        } catch (final Exception e) {
-            result = false;
-        }
-        return result;
     }
 
     public String trafficType() {
@@ -306,10 +256,6 @@ public class SplitClientConfig {
         return _segmentsRefreshRate;
     }
 
-    public int numThreadsForSegmentFetch() {
-        return _numThreadsForSegmentFetch;
-    }
-
     public int impressionsRefreshRate() {
         return _impressionsRefreshRate;
     }
@@ -326,20 +272,12 @@ public class SplitClientConfig {
         return _impressionsPerPush;
     }
 
-    public int metricsRefreshRate() {
-        return _metricsRefreshRate;
-    }
-
     public int connectionTimeout() {
         return _connectionTimeout;
     }
 
     public int readTimeout() {
         return _readTimeout;
-    }
-
-    public boolean debugEnabled() {
-        return _debugEnabled;
     }
 
     public boolean labelsEnabled() {
@@ -352,10 +290,6 @@ public class SplitClientConfig {
 
     public ImpressionListener impressionListener() {
         return _impressionListener;
-    }
-
-    public int waitBeforeShutdown() {
-        return _waitBeforeShutdown;
     }
 
     public HttpProxy proxy() {
@@ -375,48 +309,6 @@ public class SplitClientConfig {
     }
 
     /**
-     * Maximum attempts count while sending impressions.
-     * to the server. Internal setting.
-     *
-     * @return Maximum attempts limit.
-     */
-
-    int impressionsMaxSentAttempts() {
-        return _impressionsMaxSentAttempts;
-    }
-
-    /**
-     * Elapsed time in millis to consider that a chunk of impression
-     * is outdated. Internal property
-     *
-     * @return Time in millis.
-     */
-    long impressionsChunkOutdatedTime() {
-        return _impressionsChunkOudatedTime;
-    }
-
-    /**
-     * Maximum attempts count while sending tracks
-     * to the server. Internal setting.
-     *
-     * @return Maximum attempts limit.
-     */
-
-    int eventsMaxSentAttempts() {
-        return EVENTS_MAX_SENT_ATTEMPS;
-    }
-
-    /**
-     * Maximum events queue size in bytes
-     *
-     * @return Maximum events queue size in bytes.
-     */
-    int maxQueueSizeInBytes() {
-        return MAX_QUEUE_SIZE_IN_BYTES;
-    }
-
-
-    /**
      * Regex to validate Track event name
      *
      * @return Regex pattern string
@@ -424,7 +316,6 @@ public class SplitClientConfig {
     String trackEventNamePattern() {
         return TRACK_EVENT_NAME_PATTERN;
     }
-
 
     /**
      * Maximum key char length for matching and bucketing
@@ -470,14 +361,6 @@ public class SplitClientConfig {
         return _streamingEnabled;
     }
 
-    public int authRetryBackoffBase() {
-        return _authRetryBackoffBase;
-    }
-
-    public int streamingReconnectBackoffBase() {
-        return _streamingReconnectBackoffBase;
-    }
-
     public String authServiceUrl() {
         return _authServiceUrl;
     }
@@ -510,13 +393,10 @@ public class SplitClientConfig {
         return _impCountersRefreshRate;
     }
 
-    public int uniqueKeysRefreshRate() {
-        return _mtkRefreshRate;
-    }
-
     public boolean persistentAttributesEnabled() {
         return _isPersistentAttributesEnabled;
     }
+
     public int offlineRefreshRate() { return  _offlineRefreshRate; }
 
     public boolean shouldRecordTelemetry() {
@@ -551,13 +431,9 @@ public class SplitClientConfig {
         private int _impCountersRefreshRate = DEFAULT_IMP_COUNTERS_REFRESH_RATE_SECS;
         private int _connectionTimeout = DEFAULT_CONNECTION_TIMEOUT_SECS;
         private int _readTimeout = DEFAULT_READ_TIMEOUT_SECS;
-        private int _numThreadsForSegmentFetch = DEFAULT_NUM_THREAD_FOR_SEGMENT_FETCH;
-        private boolean _debugEnabled = false;
         private int _ready = DEFAULT_READY; // -1 means no blocking
-        private int _metricsRefreshRate = DEFAULT_METRICS_REFRESH_RATE_SECS;
         private boolean _labelsEnabled = true;
         private ImpressionListener _impressionListener;
-        private int _waitBeforeShutdown = DEFAULT_WAIT_BEFORE_SHUTDOW_SECS;
         private long _impressionsChunkSize = DEFAULT_IMPRESSIONS_CHUNK_SIZE; //2KB default size
         private boolean _isPersistentAttributesEnabled = false;
         static final int OFFLINE_REFRESH_RATE_DEFAULT = -1;
@@ -582,9 +458,6 @@ public class SplitClientConfig {
 
         // Push notification settings
         private boolean _streamingEnabled = true;
-        private int _authRetryBackoffBase = DEFAULT_AUTH_RETRY_BACKOFF_BASE_SECS;
-        private int _streamingReconnectBackoffBase
-                = DEFAULT_STREAMING_RECONNECT_BACKOFF_BASE_SECS;
 
         private DevelopmentSslConfig _developmentSslConfig;
 
@@ -602,7 +475,7 @@ public class SplitClientConfig {
 
         private int _logLevel = SplitLogLevel.NONE;
 
-        private int _mtkPerPush = DEFAULT_MTK_PER_PUSH;
+        private final int _mtkPerPush = DEFAULT_MTK_PER_PUSH;
 
         private final int _mtkRefreshRate = 15 * 60;
 
@@ -762,28 +635,11 @@ public class SplitClientConfig {
         }
 
         /**
-         * The diagnostic metrics collected by the SDK are pushed back to split endpoint
-         * at this period.
-         * <p/>
-         * This is an ADVANCED parameter
-         *
-         * @deprecated This parameter is now ignored.
-         * @param seconds MUST be > 0.
-         * @return this builder
-         */
-        @Deprecated
-        public Builder metricsRefreshRate(int seconds) {
-            _metricsRefreshRate = seconds;
-            return this;
-        }
-
-        /**
          * Http client connection timeout. Default value is 15000ms.
          *
          * @param ms MUST be greater than 0.
          * @return this builder
          */
-
         public Builder connectionTimeout(int ms) {
             _connectionTimeout = ms;
             return this;
@@ -797,17 +653,6 @@ public class SplitClientConfig {
          */
         public Builder readTimeout(int ms) {
             _readTimeout = ms;
-            return this;
-        }
-
-        /**
-         * Enables debug logging
-         * @deprecated  This function is deprecated. Use {@link #logLevel(int)} instead.
-         * @return this builder
-         */
-        @Deprecated
-        public Builder enableDebug() {
-            _debugEnabled = true;
             return this;
         }
 
@@ -857,18 +702,6 @@ public class SplitClientConfig {
          */
         public Builder ready(int milliseconds) {
             _ready = milliseconds;
-            return this;
-        }
-
-        /**
-         * How long to wait for impressions background thread before shutting down
-         * the underlying connections.
-         *
-         * @param waitTime tine in milliseconds
-         * @return this builder
-         */
-        public Builder waitBeforeShutdown(int waitTime) {
-            _waitBeforeShutdown = waitTime;
             return this;
         }
 
@@ -941,7 +774,7 @@ public class SplitClientConfig {
          *
          * @return this builder
          */
-        public Builder sychronizeInBackground(boolean synchronizeInBackground) {
+        public Builder synchronizeInBackground(boolean synchronizeInBackground) {
             _synchronizeInBackground = synchronizeInBackground;
             return this;
         }
@@ -953,7 +786,7 @@ public class SplitClientConfig {
          *
          * @return this builder
          */
-        public Builder sychronizeInBackgroundPeriod(long backgroundSyncPeriod) {
+        public Builder synchronizeInBackgroundPeriod(long backgroundSyncPeriod) {
             _backgroundSyncPeriod = backgroundSyncPeriod;
             return this;
         }
@@ -992,31 +825,6 @@ public class SplitClientConfig {
             _streamingEnabled = streamingEnabled;
             return this;
         }
-
-        /**
-         * How many seconds to wait before re attempting to authenticate for push notifications.
-         * Minimum: 1 seconds
-         *
-         * @param authRetryBackoffBase
-         * @return this builder
-         * @default: 1 second
-         */
-        public Builder authRetryBackoffBase(int authRetryBackoffBase) {
-            _authRetryBackoffBase = authRetryBackoffBase;
-            return this;
-        }
-
-        /**
-         * How many seconds to wait before re attempting to connect to streaming.
-         *
-         * @return: This builder
-         * @default: 1 Second
-         */
-        public Builder streamingReconnectBackoffBase(int streamingReconnectBackoffBase) {
-            _streamingReconnectBackoffBase = streamingReconnectBackoffBase;
-            return this;
-        }
-
 
         /**
          * Alternative service endpoints URL. Should only be adjusted for playing well in test environments.
@@ -1150,49 +958,45 @@ public class SplitClientConfig {
 
 
             if (_featuresRefreshRate < MIN_FEATURES_REFRESH_RATE) {
-                throw new IllegalArgumentException("featuresRefreshRate must be >= 30: " + _featuresRefreshRate);
+                Logger.w("Features refresh rate is lower than allowed. " +
+                        "Setting to default value.");
+                _featuresRefreshRate = DEFAULT_FEATURES_REFRESH_RATE_SECS;
             }
 
             if (_segmentsRefreshRate < MIN_MYSEGMENTS_REFRESH_RATE) {
-                throw new IllegalArgumentException("segmentsRefreshRate must be >= 30: " + _segmentsRefreshRate);
+                Logger.w("Segments refresh rate is lower than allowed. " +
+                        "Setting to default value.");
+                _segmentsRefreshRate = DEFAULT_SEGMENTS_REFRESH_RATE_SECS;
             }
 
             if (_impressionsRefreshRate < MIN_IMPRESSIONS_REFRESH_RATE) {
-                throw new IllegalArgumentException("impressionsRefreshRate must be >= 30: " + _impressionsRefreshRate);
-            }
-
-            if (_metricsRefreshRate < MIN_METRICS_REFRESH_RATE) {
-                throw new IllegalArgumentException("metricsRefreshRate must be >= 30: " + _metricsRefreshRate);
+                Logger.w("Impressions refresh rate is lower than allowed. " +
+                        "Setting to default value.");
+                _impressionsRefreshRate = DEFAULT_IMPRESSIONS_REFRESH_RATE_SECS;
             }
 
             if (_impressionsQueueSize <= MIN_IMPRESSIONS_QUEUE_SIZE) {
-                throw new IllegalArgumentException("impressionsQueueSize must be > 0: " + _impressionsQueueSize);
+                Logger.w("Impressions queue size is lower than allowed. " +
+                        "Setting to default value.");
+                _impressionsQueueSize = DEFAULT_IMPRESSIONS_QUEUE_SIZE;
             }
 
             if (_impressionsChunkSize <= MIN_IMPRESSIONS_CHUNK_SIZE) {
-                throw new IllegalArgumentException("impressionsChunkSize must be > 0: " + _impressionsChunkSize);
+                Logger.w("Impressions chunk size is lower than allowed. " +
+                        "Setting to default value.");
+                _impressionsChunkSize = DEFAULT_IMPRESSIONS_CHUNK_SIZE;
             }
 
             if (_connectionTimeout <= MIN_CONNECTION_TIMEOUT) {
-                throw new IllegalArgumentException("connectionTimeOutInMs must be > 0: " + _connectionTimeout);
+                Logger.w("Connection timeout is lower than allowed. " +
+                        "Setting to default value.");
+                _connectionTimeout = DEFAULT_CONNECTION_TIMEOUT_SECS;
             }
 
             if (_readTimeout <= MIN_READ_TIMEOUT) {
-                throw new IllegalArgumentException("readTimeout must be > 0: " + _readTimeout);
-            }
-
-            if (_numThreadsForSegmentFetch <= 0) {
-                throw new IllegalArgumentException("Number of threads for fetching segments MUST be greater than zero");
-            }
-
-            if (_authRetryBackoffBase < 1) {
-                throw new IllegalArgumentException("Re attempting time to authenticate " +
-                        "for push notifications MUST be greater than zero");
-            }
-
-            if (_authRetryBackoffBase < 1) {
-                throw new IllegalArgumentException("Re attempting time to connect to " +
-                        "streaming notifications MUST be greater than zero");
+                Logger.w("Read timeout is lower than allowed. " +
+                        "Setting to default value.");
+                _readTimeout = DEFAULT_READ_TIMEOUT_SECS;
             }
 
             if (_backgroundSyncPeriod < DEFAULT_BACKGROUND_SYNC_PERIOD_MINUTES) {
@@ -1218,15 +1022,11 @@ public class SplitClientConfig {
                     _impressionsQueueSize,
                     _impressionsChunkSize,
                     _impressionsPerPush,
-                    _metricsRefreshRate,
                     _connectionTimeout,
                     _readTimeout,
-                    _numThreadsForSegmentFetch,
                     _ready,
-                    _debugEnabled,
                     _labelsEnabled,
                     _impressionListener,
-                    _waitBeforeShutdown,
                     _hostname,
                     _ip,
                     proxy,
@@ -1240,8 +1040,6 @@ public class SplitClientConfig {
                     _backgroundSyncWhenBatteryNotLow,
                     _backgroundSyncWhenWifiOnly,
                     _streamingEnabled,
-                    _authRetryBackoffBase,
-                    _streamingReconnectBackoffBase,
                     _serviceEndpoints.getAuthServiceEndpoint(),
                     _serviceEndpoints.getStreamingServiceEndpoint(),
                     _developmentSslConfig,
@@ -1258,10 +1056,6 @@ public class SplitClientConfig {
                     _logLevel,
                     _mtkPerPush,
                     _mtkRefreshRate);
-        }
-
-        public void set_impressionsChunkSize(long _impressionsChunkSize) {
-            this._impressionsChunkSize = _impressionsChunkSize;
         }
 
         private HttpProxy parseProxyHost(String proxyUri) {

--- a/src/main/java/io/split/android/client/storage/db/impressions/unique/UniqueKeyEntity.java
+++ b/src/main/java/io/split/android/client/storage/db/impressions/unique/UniqueKeyEntity.java
@@ -3,6 +3,7 @@ package io.split.android.client.storage.db.impressions.unique;
 import androidx.annotation.NonNull;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
+import androidx.room.Ignore;
 import androidx.room.Index;
 import androidx.room.PrimaryKey;
 
@@ -33,6 +34,7 @@ public class UniqueKeyEntity implements Identifiable {
 
     }
 
+    @Ignore
     public UniqueKeyEntity(@NonNull String userKey, String featureList, long createdAt, int status) {
         this.userKey = userKey;
         this.featureList = featureList;

--- a/src/test/java/io/split/android/client/SplitClientConfigTest.java
+++ b/src/test/java/io/split/android/client/SplitClientConfigTest.java
@@ -1,47 +1,49 @@
 package io.split.android.client;
 
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
 
 import org.junit.Test;
 
 public class SplitClientConfigTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void cannot_set_feature_refresh_rate_to_less_than_30() {
-        SplitClientConfig.builder()
+        SplitClientConfig build = SplitClientConfig.builder()
                 .featuresRefreshRate(29)
                 .build();
+
+        assertFalse(build.featuresRefreshRate() == 29);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void cannot_set_segment_refresh_rate_to_less_than_30() {
-        SplitClientConfig.builder()
+        SplitClientConfig build = SplitClientConfig.builder()
                 .segmentsRefreshRate(29)
                 .build();
+
+        assertFalse(build.segmentsRefreshRate() == 29);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void cannot_set_impression_refresh_rate_to_less_than_30() {
-        SplitClientConfig.builder()
+        SplitClientConfig build = SplitClientConfig.builder()
                 .impressionsRefreshRate(29)
                 .build();
-    }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void cannot_set_metrics_refresh_rate_to_less_than_30() {
-        SplitClientConfig.builder()
-                .metricsRefreshRate(29)
-                .build();
+        assertFalse(build.impressionsRefreshRate() == 29);
     }
 
     @Test
     public void can_set_refresh_rates_to__30() {
-        SplitClientConfig.builder()
+        SplitClientConfig build = SplitClientConfig.builder()
                 .featuresRefreshRate(30)
                 .segmentsRefreshRate(30)
                 .impressionsRefreshRate(30)
-                .metricsRefreshRate(30)
                 .build();
+
+        assertEquals(30, build.featuresRefreshRate());
     }
 
     @Test

--- a/src/test/java/io/split/android/client/service/SynchronizerTest.java
+++ b/src/test/java/io/split/android/client/service/SynchronizerTest.java
@@ -205,7 +205,7 @@ public class SynchronizerTest {
     public void splitExecutorSchedule() {
         SplitClientConfig config = SplitClientConfig.builder()
                 .eventsQueueSize(10)
-                .sychronizeInBackground(false)
+                .synchronizeInBackground(false)
                 .impressionsQueueSize(3)
                 .build();
         setup(config);
@@ -252,7 +252,7 @@ public class SynchronizerTest {
     public void workManagerSchedule() throws InterruptedException {
         SplitClientConfig config = SplitClientConfig.builder()
                 .eventsQueueSize(10)
-                .sychronizeInBackground(true)
+                .synchronizeInBackground(true)
                 .impressionsQueueSize(3)
                 .build();
         setup(config);
@@ -265,7 +265,7 @@ public class SynchronizerTest {
     public void pauseImpOptimized() {
         SplitClientConfig config = SplitClientConfig.builder()
                 .eventsQueueSize(10)
-                .sychronizeInBackground(false)
+                .synchronizeInBackground(false)
                 .impressionsQueueSize(3)
                 .build();
         setup(config, ImpressionManagerConfig.Mode.OPTIMIZED);
@@ -282,7 +282,7 @@ public class SynchronizerTest {
     public void pauseImpDebug() {
         SplitClientConfig config = SplitClientConfig.builder()
                 .eventsQueueSize(10)
-                .sychronizeInBackground(false)
+                .synchronizeInBackground(false)
                 .impressionsQueueSize(3)
                 .impressionsMode("DEBUG")
                 .build();
@@ -300,7 +300,7 @@ public class SynchronizerTest {
     public void resume() {
         SplitClientConfig config = SplitClientConfig.builder()
                 .eventsQueueSize(10)
-                .sychronizeInBackground(false)
+                .synchronizeInBackground(false)
                 .impressionsQueueSize(3)
                 .build();
         setup(config);
@@ -316,7 +316,7 @@ public class SynchronizerTest {
     public void pushEvent() throws InterruptedException {
         SplitClientConfig config = SplitClientConfig.builder()
                 .eventsQueueSize(10)
-                .sychronizeInBackground(false)
+                .synchronizeInBackground(false)
                 .impressionsQueueSize(3)
                 .build();
         setup(config);
@@ -334,7 +334,7 @@ public class SynchronizerTest {
     public void pushEventReachQueueSize() throws InterruptedException {
         SplitClientConfig config = SplitClientConfig.builder()
                 .eventsQueueSize(10)
-                .sychronizeInBackground(false)
+                .synchronizeInBackground(false)
                 .impressionsQueueSize(3)
                 .build();
         setup(config);
@@ -353,7 +353,7 @@ public class SynchronizerTest {
     public void pushEventBytesLimit() throws InterruptedException {
         SplitClientConfig config = SplitClientConfig.builder()
                 .eventsQueueSize(10)
-                .sychronizeInBackground(false)
+                .synchronizeInBackground(false)
                 .impressionsQueueSize(3)
                 .build();
         setup(config);
@@ -375,7 +375,7 @@ public class SynchronizerTest {
 
         SplitClientConfig config = SplitClientConfig.builder()
                 .eventsQueueSize(10)
-                .sychronizeInBackground(false)
+                .synchronizeInBackground(false)
                 .impressionsQueueSize(3)
                 .build();
         setup(config);
@@ -401,7 +401,7 @@ public class SynchronizerTest {
     public void pushImpressionReachQueueSizeImpDebug() throws InterruptedException {
         SplitClientConfig config = SplitClientConfig.builder()
                 .eventsQueueSize(10)
-                .sychronizeInBackground(false)
+                .synchronizeInBackground(false)
                 .impressionsMode(ImpressionsMode.DEBUG)
                 .impressionsQueueSize(3)
                 .build();
@@ -421,7 +421,7 @@ public class SynchronizerTest {
     public void pushImpressionReachQueueSizeImpOptimized() throws InterruptedException {
         SplitClientConfig config = SplitClientConfig.builder()
                 .eventsQueueSize(10)
-                .sychronizeInBackground(false)
+                .synchronizeInBackground(false)
                 .impressionsMode(ImpressionsMode.OPTIMIZED)
                 .impressionsQueueSize(3)
                 .build();
@@ -441,7 +441,7 @@ public class SynchronizerTest {
     public void pushImpressionBytesLimitImpDebug() throws InterruptedException {
         SplitClientConfig config = SplitClientConfig.builder()
                 .eventsQueueSize(10)
-                .sychronizeInBackground(false)
+                .synchronizeInBackground(false)
                 .impressionsQueueSize(3)
                 .impressionsMode(ImpressionsMode.DEBUG)
                 .build();
@@ -462,7 +462,7 @@ public class SynchronizerTest {
     public void pushImpressionBytesLimitImpOptimized() throws InterruptedException {
         SplitClientConfig config = SplitClientConfig.builder()
                 .eventsQueueSize(10)
-                .sychronizeInBackground(false)
+                .synchronizeInBackground(false)
                 .impressionsQueueSize(3)
                 .impressionsMode(ImpressionsMode.OPTIMIZED)
                 .build();
@@ -482,7 +482,7 @@ public class SynchronizerTest {
     @Test
     public void loadLocalData() {
         SplitClientConfig config = SplitClientConfig.builder()
-                .sychronizeInBackground(false)
+                .synchronizeInBackground(false)
                 .build();
         setup(config);
 
@@ -516,7 +516,7 @@ public class SynchronizerTest {
     @Test
     public void loadAndSynchronizeSplits() {
         SplitClientConfig config = SplitClientConfig.builder()
-                .sychronizeInBackground(false)
+                .synchronizeInBackground(false)
                 .build();
         setup(config);
 
@@ -541,7 +541,7 @@ public class SynchronizerTest {
     @Test
     public void destroy() {
         SplitClientConfig config = SplitClientConfig.builder()
-                .sychronizeInBackground(false)
+                .synchronizeInBackground(false)
                 .build();
         setup(config);
         ImpressionManager impressionManager = mock(ImpressionManager.class);
@@ -564,7 +564,7 @@ public class SynchronizerTest {
 
     @Test
     public void loadMySegmentsFromCacheDelegatesToRegistry() {
-        setup(SplitClientConfig.builder().sychronizeInBackground(false).build());
+        setup(SplitClientConfig.builder().synchronizeInBackground(false).build());
 
         mSynchronizer.loadMySegmentsFromCache();
 
@@ -573,7 +573,7 @@ public class SynchronizerTest {
 
     @Test
     public void synchronizeMySegmentsDelegatesToRegistry() {
-        setup(SplitClientConfig.builder().sychronizeInBackground(false).build());
+        setup(SplitClientConfig.builder().synchronizeInBackground(false).build());
 
         mSynchronizer.synchronizeMySegments();
 
@@ -582,7 +582,7 @@ public class SynchronizerTest {
 
     @Test
     public void forceMySegmentsSyncDelegatesToRegistry() {
-        setup(SplitClientConfig.builder().sychronizeInBackground(false).build());
+        setup(SplitClientConfig.builder().synchronizeInBackground(false).build());
 
         mSynchronizer.forceMySegmentsSync();
 
@@ -591,7 +591,7 @@ public class SynchronizerTest {
 
     @Test
     public void destroyDelegatesToRegisteredSyncs() {
-        setup(SplitClientConfig.builder().sychronizeInBackground(false).build());
+        setup(SplitClientConfig.builder().synchronizeInBackground(false).build());
 
         mSynchronizer.destroy();
 
@@ -600,7 +600,7 @@ public class SynchronizerTest {
 
     @Test
     public void startPeriodicFetchingDelegatesToRegistry() {
-        setup(SplitClientConfig.builder().sychronizeInBackground(false).build());
+        setup(SplitClientConfig.builder().synchronizeInBackground(false).build());
 
         mSynchronizer.startPeriodicFetching();
 
@@ -609,7 +609,7 @@ public class SynchronizerTest {
 
     @Test
     public void stopPeriodicFetchingDelegatesToRegistry() {
-        setup(SplitClientConfig.builder().sychronizeInBackground(false).build());
+        setup(SplitClientConfig.builder().synchronizeInBackground(false).build());
 
         mSynchronizer.stopPeriodicFetching();
 
@@ -667,7 +667,7 @@ public class SynchronizerTest {
 
     @Test
     public void synchronizeSplitsWithSince() {
-        setup(SplitClientConfig.builder().sychronizeInBackground(false).build());
+        setup(SplitClientConfig.builder().synchronizeInBackground(false).build());
         SplitsUpdateTask task = mock(SplitsUpdateTask.class);
         when(mTaskFactory.createSplitsUpdateTask(1000)).thenReturn(task);
 

--- a/src/test/java/io/split/android/client/service/synchronizer/WorkManagerWrapperTest.java
+++ b/src/test/java/io/split/android/client/service/synchronizer/WorkManagerWrapperTest.java
@@ -19,18 +19,15 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
 
 import io.split.android.client.ServiceEndpoints;
 import io.split.android.client.SplitClientConfig;
-import io.split.android.client.service.ServiceConstants;
 import io.split.android.client.service.executor.SplitTaskType;
 import io.split.android.client.service.workmanager.EventsRecorderWorker;
 import io.split.android.client.service.workmanager.ImpressionsRecorderWorker;
 import io.split.android.client.service.workmanager.MySegmentsSyncWorker;
-import io.split.android.client.service.workmanager.SplitWorker;
 import io.split.android.client.service.workmanager.SplitsSyncWorker;
 
 public class WorkManagerWrapperTest {
@@ -52,7 +49,7 @@ public class WorkManagerWrapperTest {
                                 .telemetryServiceEndpoint("https://test.split.io/telemetry")
                                 .build()
                 )
-                .sychronizeInBackgroundPeriod(5263)
+                .synchronizeInBackgroundPeriod(5263)
                 .eventsPerPush(526)
                 .impressionsPerPush(256)
                 .backgroundSyncWhenWifiOnly(true)
@@ -202,7 +199,6 @@ public class WorkManagerWrapperTest {
 
     private void assertWorkSpecMatches(WorkSpec workSpec, WorkSpec expectedWorkSpec) {
         assertEquals(workSpec.backoffPolicy, expectedWorkSpec.backoffPolicy);
-        assertEquals(workSpec.runInForeground, expectedWorkSpec.runInForeground);
         assertEquals(workSpec.backoffDelayDuration, expectedWorkSpec.backoffDelayDuration);
         assertEquals(workSpec.constraints, expectedWorkSpec.constraints);
         assertEquals(workSpec.initialDelay, expectedWorkSpec.initialDelay);


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Removed unused and deprecated methods from `SplitClientConfig`.

**Removed:**
```
public int numThreadsForSegmentFetch()
public int metricsRefreshRate()
public boolean debugEnabled()
public int waitBeforeShutdown()
public int authRetryBackoffBase()
public int streamingReconnectBackoffBase()
public int uniqueKeysRefreshRate()
public void set_impressionsChunkSize(long _impressionsChunkSize)
public Builder metricsRefreshRate(int seconds)
public Builder enableDebug()
public Builder waitBeforeShutdown(int waitTime)
public Builder authRetryBackoffBase(int authRetryBackoffBase)
public Builder streamingReconnectBackoffBase(int streamingReconnectBackoffBase)
```
    
**Renamed:**
```
public Builder synchronizeInBackground(boolean synchronizeInBackground)
public Builder synchronizeInBackgroundPeriod(long backgroundSyncPeriod)
```