### PR TITLE
New update notification fields

### DIFF
--- a/src/main/java/io/split/android/client/service/sseclient/notifications/SplitsChangeNotification.java
+++ b/src/main/java/io/split/android/client/service/sseclient/notifications/SplitsChangeNotification.java
@@ -1,8 +1,31 @@
 package io.split.android.client.service.sseclient.notifications;
 
+import androidx.annotation.Nullable;
+
+import com.google.gson.annotations.SerializedName;
+
+import io.split.android.client.common.CompressionType;
+
 public class SplitsChangeNotification extends IncomingNotification {
+
+    @SerializedName("changeNumber")
     private long changeNumber;
 
+    @SerializedName("pcn")
+    @Nullable
+    private Long previousChangeNumber;
+
+    @SerializedName("d")
+    @Nullable
+    private String data;
+
+    @SerializedName("c")
+    @Nullable
+    private CompressionType compressionType;
+
+    public SplitsChangeNotification() {
+
+    }
 
     public SplitsChangeNotification(long changeNumber) {
         this.changeNumber = changeNumber;
@@ -11,5 +34,19 @@ public class SplitsChangeNotification extends IncomingNotification {
     public long getChangeNumber() {
         return changeNumber;
     }
-}
 
+    @Nullable
+    public Long getPreviousChangeNumber() {
+        return previousChangeNumber;
+    }
+
+    @Nullable
+    public String getData() {
+        return data;
+    }
+
+    @Nullable
+    public CompressionType getCompressionType() {
+        return compressionType;
+    }
+}

--- a/src/test/java/io/split/android/client/service/sseclient/sseclient/notifications/SplitsChangeNotificationTest.java
+++ b/src/test/java/io/split/android/client/service/sseclient/sseclient/notifications/SplitsChangeNotificationTest.java
@@ -11,7 +11,9 @@ import io.split.android.client.utils.Json;
 
 public class SplitsChangeNotificationTest {
 
-    private static final String FULL_NOTIFICATION = "{\"type\":\"SPLIT_UPDATE\",\"changeNumber\":1684265694505,\"pcn\":0,\"c\":2,\"d\":\"redacted=\"}";
+    private static final String FULL_NOTIFICATION_C0 = "{\"type\":\"SPLIT_UPDATE\",\"changeNumber\":1684265694505,\"pcn\":0,\"c\":0,\"d\":\"redacted=\"}";
+    private static final String FULL_NOTIFICATION_C1 = "{\"type\":\"SPLIT_UPDATE\",\"changeNumber\":1684265694505,\"pcn\":0,\"c\":1,\"d\":\"redacted=\"}";
+    private static final String FULL_NOTIFICATION_C2 = "{\"type\":\"SPLIT_UPDATE\",\"changeNumber\":1684265694505,\"pcn\":0,\"c\":2,\"d\":\"redacted=\"}";
 
     private static final String LEGACY_NOTIFICATION = "{\"type\":\"SPLIT_UPDATE\",\"changeNumber\":1684265694505}";
 
@@ -27,11 +29,15 @@ public class SplitsChangeNotificationTest {
 
     @Test
     public void valuesAreCorrectlyDeserialized() {
-        SplitsChangeNotification splitsChangeNotification = Json.fromJson(FULL_NOTIFICATION, SplitsChangeNotification.class);
+        SplitsChangeNotification c0Notification = Json.fromJson(FULL_NOTIFICATION_C0, SplitsChangeNotification.class);
+        SplitsChangeNotification c1Notification = Json.fromJson(FULL_NOTIFICATION_C1, SplitsChangeNotification.class);
+        SplitsChangeNotification c2Notification = Json.fromJson(FULL_NOTIFICATION_C2, SplitsChangeNotification.class);
 
-        assertEquals(1684265694505L, splitsChangeNotification.getChangeNumber());
-        assertEquals(0L, splitsChangeNotification.getPreviousChangeNumber().longValue());
-        assertEquals("redacted=", splitsChangeNotification.getData());
-        assertEquals(CompressionType.ZLIB, splitsChangeNotification.getCompressionType());
+        assertEquals(CompressionType.NONE, c0Notification.getCompressionType());
+        assertEquals(CompressionType.GZIP, c1Notification.getCompressionType());
+        assertEquals(1684265694505L, c2Notification.getChangeNumber());
+        assertEquals(0L, c2Notification.getPreviousChangeNumber().longValue());
+        assertEquals("redacted=", c2Notification.getData());
+        assertEquals(CompressionType.ZLIB, c2Notification.getCompressionType());
     }
 }

--- a/src/test/java/io/split/android/client/service/sseclient/sseclient/notifications/SplitsChangeNotificationTest.java
+++ b/src/test/java/io/split/android/client/service/sseclient/sseclient/notifications/SplitsChangeNotificationTest.java
@@ -1,0 +1,37 @@
+package io.split.android.client.service.sseclient.sseclient.notifications;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import io.split.android.client.common.CompressionType;
+import io.split.android.client.service.sseclient.notifications.SplitsChangeNotification;
+import io.split.android.client.utils.Json;
+
+public class SplitsChangeNotificationTest {
+
+    private static final String FULL_NOTIFICATION = "{\"type\":\"SPLIT_UPDATE\",\"changeNumber\":1684265694505,\"pcn\":0,\"c\":2,\"d\":\"redacted=\"}";
+
+    private static final String LEGACY_NOTIFICATION = "{\"type\":\"SPLIT_UPDATE\",\"changeNumber\":1684265694505}";
+
+    @Test
+    public void nullValuesAreAllowed() {
+        SplitsChangeNotification splitsChangeNotification = Json.fromJson(LEGACY_NOTIFICATION, SplitsChangeNotification.class);
+
+        assertEquals(1684265694505L, splitsChangeNotification.getChangeNumber());
+        assertNull(splitsChangeNotification.getPreviousChangeNumber());
+        assertNull(splitsChangeNotification.getData());
+        assertNull(splitsChangeNotification.getCompressionType());
+    }
+
+    @Test
+    public void valuesAreCorrectlyDeserialized() {
+        SplitsChangeNotification splitsChangeNotification = Json.fromJson(FULL_NOTIFICATION, SplitsChangeNotification.class);
+
+        assertEquals(1684265694505L, splitsChangeNotification.getChangeNumber());
+        assertEquals(0L, splitsChangeNotification.getPreviousChangeNumber().longValue());
+        assertEquals("redacted=", splitsChangeNotification.getData());
+        assertEquals(CompressionType.ZLIB, splitsChangeNotification.getCompressionType());
+    }
+}


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Added `previousChangeNumber`, `data` and `compressionType` fields to `SplitsChangeNotification`.