### PR TITLE
Clear cache on filter change

### DIFF
--- a/src/androidTest/java/fake/SynchronizerSpyImpl.java
+++ b/src/androidTest/java/fake/SynchronizerSpyImpl.java
@@ -31,11 +31,6 @@ public class SynchronizerSpyImpl implements SynchronizerSpy, MySegmentsSynchroni
     }
 
     @Override
-    public void loadSplitsFromCache() {
-        mSynchronizer.loadSplitsFromCache();
-    }
-
-    @Override
     public void loadMySegmentsFromCache() {
         mSynchronizer.loadMySegmentsFromCache();
     }

--- a/src/androidTest/java/tests/storage/LoadSplitTaskTest.java
+++ b/src/androidTest/java/tests/storage/LoadSplitTaskTest.java
@@ -53,9 +53,9 @@ public class LoadSplitTaskTest {
     }
 
     @Test
-    public void execute() {
+    public void executeWithoutQueryString() {
 
-        SplitTask task = new LoadSplitsTask(mSplitsStorage);
+        SplitTask task = new LoadSplitsTask(mSplitsStorage, null);
         SplitTaskExecutionInfo result = task.execute();
 
         Split split0 = mSplitsStorage.get("split-0");
@@ -68,5 +68,26 @@ public class LoadSplitTaskTest {
         Assert.assertNotNull(split2);
         Assert.assertNotNull(split3);
         Assert.assertEquals(SplitTaskExecutionStatus.SUCCESS, result.getStatus());
+        Assert.assertEquals(9999L, mSplitsStorage.getTill());
+        Assert.assertEquals("", mSplitsStorage.getSplitsFilterQueryString());
+    }
+
+    @Test
+    public void executeWithQueryString() {
+
+        SplitTask task = new LoadSplitsTask(mSplitsStorage, "sets=set1");
+        SplitTaskExecutionInfo result = task.execute();
+
+        Split split0 = mSplitsStorage.get("split-0");
+        Split split1 = mSplitsStorage.get("split-1");
+        Split split2 = mSplitsStorage.get("split-2");
+        Split split3 = mSplitsStorage.get("split-3");
+        Assert.assertNull(split0);
+        Assert.assertNull(split1);
+        Assert.assertNull(split2);
+        Assert.assertNull(split3);
+        Assert.assertEquals(SplitTaskExecutionStatus.ERROR, result.getStatus());
+        Assert.assertEquals(-1L, mSplitsStorage.getTill());
+        Assert.assertEquals("sets=set1", mSplitsStorage.getSplitsFilterQueryString());
     }
 }

--- a/src/main/java/io/split/android/client/SplitFactoryImpl.java
+++ b/src/main/java/io/split/android/client/SplitFactoryImpl.java
@@ -173,14 +173,14 @@ public class SplitFactoryImpl implements SplitFactory {
 
         Pair<Pair<List<SplitFilter>, String>, Set<String>> filtersConfig = factoryHelper.getFilterConfiguration(config.syncConfig());
         List<SplitFilter> filters = filtersConfig.first.first;
-        String splitsFilterQueryString = filtersConfig.first.second;
+        String splitsFilterQueryStringFromConfig = filtersConfig.first.second;
         Set<String> configuredFlagSets = filtersConfig.second;
 
         SplitApiFacade splitApiFacade = factoryHelper.buildApiFacade(
-                config, defaultHttpClient, splitsFilterQueryString);
+                config, defaultHttpClient, splitsFilterQueryStringFromConfig);
 
         SplitTaskFactory splitTaskFactory = new SplitTaskFactoryImpl(
-                config, splitApiFacade, mStorageContainer, splitsFilterQueryString, mEventsManagerCoordinator,
+                config, splitApiFacade, mStorageContainer, splitsFilterQueryStringFromConfig, mEventsManagerCoordinator,
                 filters, configuredFlagSets, testingConfig);
 
         cleanUpDabase(splitTaskExecutor, splitTaskFactory);
@@ -205,7 +205,8 @@ public class SplitFactoryImpl implements SplitFactory {
                 impressionManager,
                 mStorageContainer.getEventsStorage(),
                 mEventsManagerCoordinator,
-                streamingComponents.getPushManagerEventBroadcaster());
+                streamingComponents.getPushManagerEventBroadcaster(),
+                splitsFilterQueryStringFromConfig);
         // Only available for integration tests
         if (synchronizerSpy != null) {
             synchronizerSpy.setSynchronizer(mSynchronizer);

--- a/src/main/java/io/split/android/client/localhost/LocalhostSplitFactory.java
+++ b/src/main/java/io/split/android/client/localhost/LocalhostSplitFactory.java
@@ -7,11 +7,13 @@ import androidx.annotation.VisibleForTesting;
 
 import java.io.IOException;
 
+import io.split.android.client.FilterBuilder;
 import io.split.android.client.SplitClient;
 import io.split.android.client.SplitClientConfig;
 import io.split.android.client.SplitFactory;
 import io.split.android.client.SplitManager;
 import io.split.android.client.SplitManagerImpl;
+import io.split.android.client.SyncConfig;
 import io.split.android.client.api.Key;
 import io.split.android.client.attributes.AttributesManagerFactory;
 import io.split.android.client.attributes.AttributesManagerFactoryImpl;
@@ -77,7 +79,7 @@ public class LocalhostSplitFactory implements SplitFactory {
                 eventsManagerCoordinator,
                 taskExecutor);
 
-        mSynchronizer = new LocalhostSynchronizer(taskExecutor, config, splitsStorage);
+        mSynchronizer = new LocalhostSynchronizer(taskExecutor, config, splitsStorage, buildQueryString(config.syncConfig()));
         mSynchronizer.start();
 
         Logger.i("Android SDK initialized!");
@@ -140,5 +142,14 @@ public class LocalhostSplitFactory implements SplitFactory {
     @Override
     public UserConsent getUserConsent() {
         return UserConsent.GRANTED;
+    }
+
+    private static String buildQueryString(SyncConfig syncConfig) {
+        if (syncConfig != null) {
+            FilterBuilder filterBuilder = new FilterBuilder(syncConfig.getFilters());
+            return filterBuilder.buildQueryString();
+        }
+
+        return "";
     }
 }

--- a/src/main/java/io/split/android/client/localhost/LocalhostSynchronizer.java
+++ b/src/main/java/io/split/android/client/localhost/LocalhostSynchronizer.java
@@ -3,6 +3,7 @@ package io.split.android.client.localhost;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import javax.security.auth.Destroyable;
 
@@ -18,17 +19,20 @@ public class LocalhostSynchronizer implements SplitLifecycleAware, Destroyable {
     private final SplitTaskExecutor mTaskExecutor;
     private final int mRefreshRate;
     private final SplitsStorage mSplitsStorage;
+    private final String mSplitsFilterQueryStringFromConfig;
 
     public LocalhostSynchronizer(@NonNull SplitTaskExecutor taskExecutor,
                                  @NonNull SplitClientConfig splitClientConfig,
-                                 @NonNull SplitsStorage splitsStorage) {
+                                 @NonNull SplitsStorage splitsStorage,
+                                 @Nullable String splitsFilterQueryStringFromConfig) {
         mTaskExecutor = checkNotNull(taskExecutor);
         mRefreshRate = checkNotNull(splitClientConfig).offlineRefreshRate();
         mSplitsStorage = checkNotNull(splitsStorage);
+        mSplitsFilterQueryStringFromConfig = splitsFilterQueryStringFromConfig;
     }
 
     public void start() {
-        SplitTask loadTask = new LoadSplitsTask(mSplitsStorage);
+        SplitTask loadTask = new LoadSplitsTask(mSplitsStorage, mSplitsFilterQueryStringFromConfig);
         if (mRefreshRate > 0) {
             mTaskExecutor.schedule(
                     loadTask, 0,

--- a/src/main/java/io/split/android/client/service/executor/SplitTaskFactory.java
+++ b/src/main/java/io/split/android/client/service/executor/SplitTaskFactory.java
@@ -18,7 +18,7 @@ public interface SplitTaskFactory extends TelemetryTaskFactory, ImpressionsTaskF
 
     SplitsSyncTask createSplitsSyncTask(boolean checkCacheExpiration);
 
-    LoadSplitsTask createLoadSplitsTask();
+    LoadSplitsTask createLoadSplitsTask(String createLoadSplitsTask);
 
     SplitKillTask createSplitKillTask(Split split);
 

--- a/src/main/java/io/split/android/client/service/executor/SplitTaskFactoryImpl.java
+++ b/src/main/java/io/split/android/client/service/executor/SplitTaskFactoryImpl.java
@@ -130,8 +130,8 @@ public class SplitTaskFactoryImpl implements SplitTaskFactory {
     }
 
     @Override
-    public LoadSplitsTask createLoadSplitsTask() {
-        return new LoadSplitsTask(mSplitsStorageContainer.getSplitsStorage());
+    public LoadSplitsTask createLoadSplitsTask(String splitsFilterQueryStringFromConfig) {
+        return new LoadSplitsTask(mSplitsStorageContainer.getSplitsStorage(), splitsFilterQueryStringFromConfig);
     }
 
     @Override

--- a/src/main/java/io/split/android/client/service/splits/LoadSplitsTask.java
+++ b/src/main/java/io/split/android/client/service/splits/LoadSplitsTask.java
@@ -12,18 +12,31 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class LoadSplitsTask implements SplitTask {
 
     private final SplitsStorage mSplitsStorage;
+    private final String mSplitsFilterQueryStringFromConfig;
 
-    public LoadSplitsTask(SplitsStorage splitsStorage) {
+    public LoadSplitsTask(SplitsStorage splitsStorage, String splitsFilterQueryStringFromConfig) {
         mSplitsStorage = checkNotNull(splitsStorage);
+        mSplitsFilterQueryStringFromConfig = (splitsFilterQueryStringFromConfig == null) ? "" : splitsFilterQueryStringFromConfig;
     }
 
     @Override
     @NonNull
     public SplitTaskExecutionInfo execute() {
         mSplitsStorage.loadLocal();
-        if(mSplitsStorage.getTill() > -1) {
+        String queryStringFromStorage = mSplitsStorage.getSplitsFilterQueryString();
+        if (queryStringFromStorage == null) {
+            queryStringFromStorage = "";
+        }
+
+        if (mSplitsStorage.getTill() > -1 && mSplitsFilterQueryStringFromConfig.equals(queryStringFromStorage)) {
             return SplitTaskExecutionInfo.success(SplitTaskType.LOAD_LOCAL_SPLITS);
         }
+
+        if (!mSplitsFilterQueryStringFromConfig.equals(queryStringFromStorage)) {
+            mSplitsStorage.clear();
+            mSplitsStorage.updateSplitsFilterQueryString(mSplitsFilterQueryStringFromConfig);
+        }
+
         return SplitTaskExecutionInfo.error(SplitTaskType.LOAD_LOCAL_SPLITS);
     }
 }

--- a/src/main/java/io/split/android/client/service/synchronizer/FeatureFlagsSynchronizer.java
+++ b/src/main/java/io/split/android/client/service/synchronizer/FeatureFlagsSynchronizer.java
@@ -6,8 +6,6 @@ public interface FeatureFlagsSynchronizer {
 
     void loadAndSynchronize();
 
-    void loadFromCache();
-
     void synchronize(long since);
 
     void synchronize();

--- a/src/main/java/io/split/android/client/service/synchronizer/Synchronizer.java
+++ b/src/main/java/io/split/android/client/service/synchronizer/Synchronizer.java
@@ -8,8 +8,6 @@ public interface Synchronizer extends SplitLifecycleAware {
 
     void loadAndSynchronizeSplits();
 
-    void loadSplitsFromCache();
-
     void loadMySegmentsFromCache();
 
     void loadAttributesFromCache();

--- a/src/main/java/io/split/android/client/service/synchronizer/SynchronizerImpl.java
+++ b/src/main/java/io/split/android/client/service/synchronizer/SynchronizerImpl.java
@@ -63,7 +63,8 @@ public class SynchronizerImpl implements Synchronizer, SplitTaskExecutionListene
                             @NonNull ImpressionManager impressionManager,
                             @NonNull StoragePusher<Event> eventsStorage,
                             @NonNull ISplitEventsManager eventsManagerCoordinator,
-                            @Nullable PushManagerEventBroadcaster pushManagerEventBroadcaster) {
+                            @Nullable PushManagerEventBroadcaster pushManagerEventBroadcaster,
+                            @NonNull String splitsFilterQueryStringFromConfig) {
         this(splitClientConfig,
                 taskExecutor,
                 splitSingleThreadTaskExecutor,
@@ -79,7 +80,8 @@ public class SynchronizerImpl implements Synchronizer, SplitTaskExecutionListene
                         splitTaskFactory,
                         eventsManagerCoordinator,
                         retryBackoffCounterTimerFactory,
-                        pushManagerEventBroadcaster),
+                        pushManagerEventBroadcaster,
+                        splitsFilterQueryStringFromConfig),
                 eventsStorage);
     }
 
@@ -120,11 +122,6 @@ public class SynchronizerImpl implements Synchronizer, SplitTaskExecutionListene
         } else {
             workManagerWrapper.removeWork();
         }
-    }
-
-    @Override
-    public void loadSplitsFromCache() {
-        mFeatureFlagsSynchronizer.loadFromCache();
     }
 
     @Override

--- a/src/main/java/io/split/android/client/storage/splits/SplitsStorageImpl.java
+++ b/src/main/java/io/split/android/client/storage/splits/SplitsStorageImpl.java
@@ -135,6 +135,7 @@ public class SplitsStorageImpl implements SplitsStorage {
     @WorkerThread
     public void updateSplitsFilterQueryString(String queryString) {
         mPersistentStorage.updateFilterQueryString(queryString);
+        mSplitsFilterQueryString = queryString;
     }
 
     @Override

--- a/src/test/java/io/split/android/client/service/LoadSplitsTaskTest.java
+++ b/src/test/java/io/split/android/client/service/LoadSplitsTaskTest.java
@@ -1,0 +1,123 @@
+package io.split.android.client.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.split.android.client.service.executor.SplitTaskExecutionInfo;
+import io.split.android.client.service.executor.SplitTaskExecutionStatus;
+import io.split.android.client.service.executor.SplitTaskType;
+import io.split.android.client.service.splits.LoadSplitsTask;
+import io.split.android.client.storage.splits.SplitsStorage;
+
+public class LoadSplitsTaskTest {
+
+    private SplitsStorage mSplitsStorage;
+    private LoadSplitsTask mLoadSplitsTask;
+
+    @Before
+    public void setUp() {
+        mSplitsStorage = mock(SplitsStorage.class);
+    }
+
+    @Test
+    public void resultIsErrorWhenQueryStringHasChanged() {
+        when(mSplitsStorage.getTill()).thenReturn(123456677L);
+        when(mSplitsStorage.getSplitsFilterQueryString()).thenReturn("previous");
+
+        mLoadSplitsTask = new LoadSplitsTask(mSplitsStorage, "new");
+
+        SplitTaskExecutionInfo info = mLoadSplitsTask.execute();
+
+        assertEquals(SplitTaskExecutionStatus.ERROR, info.getStatus());
+        assertEquals(SplitTaskType.LOAD_LOCAL_SPLITS, info.getTaskType());
+    }
+
+    @Test
+    public void resultIsSuccessWhenQueryStringIsSame() {
+        when(mSplitsStorage.getTill()).thenReturn(123456677L);
+        when(mSplitsStorage.getSplitsFilterQueryString()).thenReturn("previous");
+
+        mLoadSplitsTask = new LoadSplitsTask(mSplitsStorage, "previous");
+
+        SplitTaskExecutionInfo info = mLoadSplitsTask.execute();
+
+        assertEquals(SplitTaskExecutionStatus.SUCCESS, info.getStatus());
+        assertEquals(SplitTaskType.LOAD_LOCAL_SPLITS, info.getTaskType());
+    }
+
+    @Test
+    public void loadLocalIsCalledOnStorageWhenExecutingTask() {
+        when(mSplitsStorage.getTill()).thenReturn(123456677L);
+
+        mLoadSplitsTask = new LoadSplitsTask(mSplitsStorage, null);
+
+        mLoadSplitsTask.execute();
+
+        verify(mSplitsStorage).loadLocal();
+    }
+
+    @Test
+    public void resultIsErrorWhenTillIsNegativeOne() {
+        when(mSplitsStorage.getTill()).thenReturn(-1L);
+
+        mLoadSplitsTask = new LoadSplitsTask(mSplitsStorage, null);
+
+        SplitTaskExecutionInfo info = mLoadSplitsTask.execute();
+
+        assertEquals(SplitTaskExecutionStatus.ERROR, info.getStatus());
+        assertEquals(SplitTaskType.LOAD_LOCAL_SPLITS, info.getTaskType());
+    }
+
+    @Test
+    public void clearIsNotCalledWhenTillIsNegativeOne() {
+        when(mSplitsStorage.getTill()).thenReturn(-1L);
+
+        mLoadSplitsTask = new LoadSplitsTask(mSplitsStorage, null);
+
+        mLoadSplitsTask.execute();
+
+        verify(mSplitsStorage, times(0)).clear();
+    }
+
+    @Test
+    public void clearIsCalledOnStorageWhenQueryStringsDiffer() {
+        when(mSplitsStorage.getTill()).thenReturn(123456677L);
+        when(mSplitsStorage.getSplitsFilterQueryString()).thenReturn("previous");
+
+        mLoadSplitsTask = new LoadSplitsTask(mSplitsStorage, "new");
+
+        mLoadSplitsTask.execute();
+
+        verify(mSplitsStorage).clear();
+    }
+
+    @Test
+    public void clearIsNotCalledOnStorageWhenQueryStringsAreEquallyNull() {
+        when(mSplitsStorage.getTill()).thenReturn(123456677L);
+        when(mSplitsStorage.getSplitsFilterQueryString()).thenReturn(null);
+
+        mLoadSplitsTask = new LoadSplitsTask(mSplitsStorage, null);
+
+        mLoadSplitsTask.execute();
+
+        verify(mSplitsStorage, times(0)).clear();
+    }
+
+    @Test
+    public void clearIsNotCalledOnStorageWhenQueryStringsAreEqual() {
+        when(mSplitsStorage.getTill()).thenReturn(123456677L);
+        when(mSplitsStorage.getSplitsFilterQueryString()).thenReturn("");
+
+        mLoadSplitsTask = new LoadSplitsTask(mSplitsStorage, "");
+
+        mLoadSplitsTask.execute();
+
+        verify(mSplitsStorage, times(0)).clear();
+    }
+}

--- a/src/test/java/io/split/android/client/service/SynchronizerTest.java
+++ b/src/test/java/io/split/android/client/service/SynchronizerTest.java
@@ -176,7 +176,7 @@ public class SynchronizerTest {
         when(mMySegmentsTaskFactory.createMySegmentsSyncTask(anyBoolean())).thenReturn(Mockito.mock(MySegmentsSyncTask.class));
         when(mTaskFactory.createImpressionsRecorderTask()).thenReturn(Mockito.mock(ImpressionsRecorderTask.class));
         when(mTaskFactory.createEventsRecorderTask()).thenReturn(Mockito.mock(EventsRecorderTask.class));
-        when(mTaskFactory.createLoadSplitsTask()).thenReturn(Mockito.mock(LoadSplitsTask.class));
+        when(mTaskFactory.createLoadSplitsTask(any())).thenReturn(Mockito.mock(LoadSplitsTask.class));
         when(mTaskFactory.createFilterSplitsInCacheTask()).thenReturn(Mockito.mock(FilterSplitsInCacheTask.class));
         when(mTaskFactory.createImpressionsCountRecorderTask()).thenReturn(Mockito.mock(ImpressionsCountRecorderTask.class));
         when(mTaskFactory.createSaveImpressionsCountTask(any())).thenReturn(Mockito.mock(SaveImpressionsCountTask.class));
@@ -524,12 +524,12 @@ public class SynchronizerTest {
 
         ((MySegmentsSynchronizerRegistry) mSynchronizer).registerMySegmentsSynchronizer("", mMySegmentsSynchronizer);
 
-        mSynchronizer.loadSplitsFromCache();
+        mSynchronizer.loadAndSynchronizeSplits();
         mSynchronizer.loadMySegmentsFromCache();
         mSynchronizer.loadAttributesFromCache();
+        verify(mFeatureFlagsSynchronizer).loadAndSynchronize();
         verify(mMySegmentsSynchronizerRegistry).loadMySegmentsFromCache();
         verify(mAttributesSynchronizerRegistry).loadAttributesFromCache();
-        verify(mFeatureFlagsSynchronizer).loadFromCache();
     }
 
     @Test
@@ -668,7 +668,7 @@ public class SynchronizerTest {
         setup(SplitClientConfig.builder().persistentAttributesEnabled(false).build());
 
         LoadSplitsTask task = mock(LoadSplitsTask.class);
-        when(mTaskFactory.createLoadSplitsTask()).thenReturn(task);
+        when(mTaskFactory.createLoadSplitsTask(any())).thenReturn(task);
 
         mSynchronizer.taskExecuted(SplitTaskExecutionInfo.success(SplitTaskType.SPLITS_SYNC));
 

--- a/src/test/java/io/split/android/client/service/synchronizer/FeatureFlagsSynchronizerImplTest.java
+++ b/src/test/java/io/split/android/client/service/synchronizer/FeatureFlagsSynchronizerImplTest.java
@@ -64,7 +64,7 @@ public class FeatureFlagsSynchronizerImplTest {
 
         mFeatureFlagsSynchronizer = new FeatureFlagsSynchronizerImpl(mConfig,
                 mTaskExecutor, mSingleThreadTaskExecutor, mTaskFactory,
-                mEventsManager, mRetryBackoffCounterFactory, mPushManagerEventBroadcaster);
+                mEventsManager, mRetryBackoffCounterFactory, mPushManagerEventBroadcaster, "");
     }
 
     @Test
@@ -79,24 +79,10 @@ public class FeatureFlagsSynchronizerImplTest {
     }
 
     @Test
-    public void loadLocalData() {
-        LoadSplitsTask mockTask = mock(LoadSplitsTask.class);
-        when(mockTask.execute()).thenReturn(SplitTaskExecutionInfo.success(SplitTaskType.LOAD_LOCAL_SPLITS));
-        when(mTaskFactory.createLoadSplitsTask()).thenReturn(mockTask);
-        when(mRetryBackoffCounterFactory.create(any(), anyInt()))
-                .thenReturn(mRetryTimerSplitsSync)
-                .thenReturn(mRetryTimerSplitsUpdate);
-
-        mFeatureFlagsSynchronizer.loadFromCache();
-
-        verify(mTaskExecutor).submit(eq(mockTask), argThat(Objects::nonNull));
-    }
-
-    @Test
     public void loadAndSynchronizeSplits() {
         LoadSplitsTask mockLoadTask = mock(LoadSplitsTask.class);
         when(mockLoadTask.execute()).thenReturn(SplitTaskExecutionInfo.success(SplitTaskType.LOAD_LOCAL_SPLITS));
-        when(mTaskFactory.createLoadSplitsTask()).thenReturn(mockLoadTask);
+        when(mTaskFactory.createLoadSplitsTask(any())).thenReturn(mockLoadTask);
 
         FilterSplitsInCacheTask mockFilterTask = mock(FilterSplitsInCacheTask.class);
         when(mockFilterTask.execute()).thenReturn(SplitTaskExecutionInfo.success(SplitTaskType.FILTER_SPLITS_CACHE));
@@ -113,7 +99,7 @@ public class FeatureFlagsSynchronizerImplTest {
         mFeatureFlagsSynchronizer.loadAndSynchronize();
 
         verify(mTaskFactory).createFilterSplitsInCacheTask();
-        verify(mTaskFactory).createLoadSplitsTask();
+        verify(mTaskFactory).createLoadSplitsTask(any());
 
         ArgumentCaptor<List<SplitTaskBatchItem>> argument = ArgumentCaptor.forClass(List.class);
         verify(mTaskExecutor).executeSerially(argument.capture());

--- a/src/test/java/io/split/android/client/service/telemetry/SynchronizerImplTelemetryTest.java
+++ b/src/test/java/io/split/android/client/service/telemetry/SynchronizerImplTelemetryTest.java
@@ -103,7 +103,8 @@ public class SynchronizerImplTelemetryTest {
                         mTaskFactory,
                         mEventsManager,
                         mRetryBackoffCounterFactory,
-                        mPushManagerEventBroadcaster),
+                        mPushManagerEventBroadcaster,
+                        ""),
                 mSplitStorageContainer.getEventsStorage());
     }
 


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Prevent `SDK_READY_FROM_CACHE` to be triggered when filter differs from previous initialization.
- Added the query string generated from the sync config to `LoadSplitsTask`:
  -  If the filter is different from the one in storage, storage is cleared and the filter in storage is updated. Also in that case, the task will return error (to prevent `SDK_READY_FROM_CACHE` from being triggered).
- In `SplitsStorageImpl`, fixed missing update to the in memory query string.
- Removed unnecessary methods from `Synchronizer` & `FeatureFlagsSynchronizer` interfaces. 