### PR TITLE
Prevent retry in specific tasks

### DIFF
--- a/src/main/java/io/split/android/client/service/executor/SplitTaskExecutionInfo.java
+++ b/src/main/java/io/split/android/client/service/executor/SplitTaskExecutionInfo.java
@@ -13,6 +13,7 @@ public class SplitTaskExecutionInfo {
 
     public static final String NON_SENT_RECORDS = "NON_SENT_RECORDS";
     public static final String NON_SENT_BYTES = "NON_SENT_BYTES";
+    public static final String DO_NOT_RETRY = "DO_NOT_RETRY";
 
     final private SplitTaskType taskType;
     final private SplitTaskExecutionStatus status;

--- a/src/main/java/io/split/android/client/service/executor/SplitTaskFactory.java
+++ b/src/main/java/io/split/android/client/service/executor/SplitTaskFactory.java
@@ -18,7 +18,7 @@ public interface SplitTaskFactory extends TelemetryTaskFactory, ImpressionsTaskF
 
     SplitsSyncTask createSplitsSyncTask(boolean checkCacheExpiration);
 
-    LoadSplitsTask createLoadSplitsTask(String createLoadSplitsTask);
+    LoadSplitsTask createLoadSplitsTask(String splitsFilterQueryStringFromConfig);
 
     SplitKillTask createSplitKillTask(Split split);
 

--- a/src/main/java/io/split/android/client/service/http/HttpGeneralException.java
+++ b/src/main/java/io/split/android/client/service/http/HttpGeneralException.java
@@ -4,6 +4,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 public abstract class HttpGeneralException extends Exception {
+
     private final Integer mHttpStatus;
 
     public HttpGeneralException(String path, String message, @Nullable Integer httpStatus) {

--- a/src/main/java/io/split/android/client/service/http/HttpStatus.java
+++ b/src/main/java/io/split/android/client/service/http/HttpStatus.java
@@ -1,0 +1,38 @@
+package io.split.android.client.service.http;
+
+import androidx.annotation.Nullable;
+
+public enum HttpStatus {
+
+    URI_TOO_LONG(414, "URI Too Long");
+
+    private final int mCode;
+    private final String mDescription;
+
+    HttpStatus(int code, String description) {
+        mCode = code;
+        mDescription = description;
+    }
+
+    public int getCode() {
+        return mCode;
+    }
+
+    public String getDescription() {
+        return mDescription;
+    }
+
+    @Nullable
+    public static HttpStatus fromCode(Integer code) {
+        if (code == null) {
+            return null;
+        }
+
+        for (HttpStatus status : values()) {
+            if (status.getCode() == code) {
+                return status;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/split/android/client/service/splits/SplitsSyncHelper.java
+++ b/src/main/java/io/split/android/client/service/splits/SplitsSyncHelper.java
@@ -7,6 +7,7 @@ import androidx.annotation.VisibleForTesting;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -18,6 +19,7 @@ import io.split.android.client.service.executor.SplitTaskExecutionInfo;
 import io.split.android.client.service.executor.SplitTaskType;
 import io.split.android.client.service.http.HttpFetcher;
 import io.split.android.client.service.http.HttpFetcherException;
+import io.split.android.client.service.http.HttpStatus;
 import io.split.android.client.service.sseclient.BackoffCounter;
 import io.split.android.client.service.sseclient.ReconnectBackoffCounter;
 import io.split.android.client.storage.splits.SplitsStorage;
@@ -80,6 +82,11 @@ public class SplitsSyncHelper {
         } catch (HttpFetcherException e) {
             logError("Network error while fetching feature flags" + e.getLocalizedMessage());
             mTelemetryRuntimeProducer.recordSyncError(OperationType.SPLITS, e.getHttpStatus());
+
+            if (HttpStatus.fromCode(e.getHttpStatus()) == HttpStatus.URI_TOO_LONG) {
+                return SplitTaskExecutionInfo.error(SplitTaskType.SPLITS_SYNC,
+                        Collections.singletonMap(SplitTaskExecutionInfo.DO_NOT_RETRY, true));
+            }
 
             return SplitTaskExecutionInfo.error(SplitTaskType.SPLITS_SYNC);
         } catch (Exception e) {


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Added flag to indicate that the task should not be retried when flags sync fails with a 414 http code.
- Added functionality in `RetryBackoffCounterTimer` to check whether the task has been configured to not be retried.