### PR TITLE
Sets evaluation in clients

### DIFF
--- a/src/main/java/io/split/android/client/AlwaysReturnControlSplitClient.java
+++ b/src/main/java/io/split/android/client/AlwaysReturnControlSplitClient.java
@@ -17,7 +17,7 @@ import java.util.Map;
  * Useful for testing
  *
  */
-public class AlwaysReturnControlSplitClient implements io.split.android.client.SplitClient {
+public class AlwaysReturnControlSplitClient implements SplitClient {
 
     @Override
     public String getTreatment(String featureFlagName) {
@@ -62,22 +62,22 @@ public class AlwaysReturnControlSplitClient implements io.split.android.client.S
 
     @Override
     public Map<String, String> getTreatmentsByFlagSet(@NonNull String flagSet, @Nullable Map<String, Object> attributes) {
-        return Collections.emptyMap(); //TODO
+        return Collections.emptyMap();
     }
 
     @Override
     public Map<String, String> getTreatmentsByFlagSets(@NonNull List<String> flagSets, @Nullable Map<String, Object> attributes) {
-        return Collections.emptyMap(); //TODO
+        return Collections.emptyMap();
     }
 
     @Override
     public Map<String, SplitResult> getTreatmentsWithConfigByFlagSet(@NonNull String flagSet, @Nullable Map<String, Object> attributes) {
-        return Collections.emptyMap(); //TODO
+        return Collections.emptyMap();
     }
 
     @Override
     public Map<String, SplitResult> getTreatmentsWithConfigByFlagSets(@NonNull List<String> flagSets, @Nullable Map<String, Object> attributes) {
-        return Collections.emptyMap(); //TODO
+        return Collections.emptyMap();
     }
 
     @Override

--- a/src/main/java/io/split/android/client/SplitClientImpl.java
+++ b/src/main/java/io/split/android/client/SplitClientImpl.java
@@ -190,38 +190,22 @@ public final class SplitClientImpl implements SplitClient {
 
     @Override
     public Map<String, String> getTreatmentsByFlagSet(@NonNull String flagSet, @Nullable Map<String, Object> attributes) {
-        try {
-            return Collections.emptyMap(); //TODO
-        } catch (Exception exception) {
-            return null;
-        }
+        return mTreatmentManager.getTreatmentsByFlagSet(flagSet, attributes, mIsClientDestroyed);
     }
 
     @Override
     public Map<String, String> getTreatmentsByFlagSets(@NonNull List<String> flagSets, @Nullable Map<String, Object> attributes) {
-        try {
-            return Collections.emptyMap(); //TODO
-        } catch (Exception exception) {
-            return null;
-        }
+        return mTreatmentManager.getTreatmentsByFlagSets(flagSets, attributes, mIsClientDestroyed);
     }
 
     @Override
     public Map<String, SplitResult> getTreatmentsWithConfigByFlagSet(@NonNull String flagSet, @Nullable Map<String, Object> attributes) {
-        try {
-            return Collections.emptyMap(); //TODO
-        } catch (Exception exception) {
-            return null;
-        }
+        return mTreatmentManager.getTreatmentsWithConfigByFlagSet(flagSet, attributes, mIsClientDestroyed);
     }
 
     @Override
     public Map<String, SplitResult> getTreatmentsWithConfigByFlagSets(@NonNull List<String> flagSets, @Nullable Map<String, Object> attributes) {
-        try {
-            return Collections.emptyMap(); //TODO
-        } catch (Exception exception) {
-            return null;
-        }
+        return mTreatmentManager.getTreatmentsWithConfigByFlagSets(flagSets, attributes, mIsClientDestroyed);
     }
 
     public void on(SplitEvent event, SplitEventTask task) {

--- a/src/main/java/io/split/android/client/validators/TreatmentManagerImpl.java
+++ b/src/main/java/io/split/android/client/validators/TreatmentManagerImpl.java
@@ -183,68 +183,100 @@ public class TreatmentManagerImpl implements TreatmentManager {
     @Override
     public Map<String, String> getTreatmentsByFlagSet(@NonNull String flagSet, @Nullable Map<String, Object> attributes, boolean isClientDestroyed) {
         String validationTag = ValidationTag.GET_TREATMENTS_BY_FLAG_SET;
-        Set<String> names = getNamesFromSet(validationTag, Collections.singletonList(flagSet));
-        if (isClientDestroyed) {
-            mValidationLogger.e(CLIENT_DESTROYED_MESSAGE, validationTag);
-            return controlTreatmentsForSplits(new ArrayList<>(names), validationTag);
-        }
-
-        long start = System.currentTimeMillis();
+        Set<String> names = new HashSet<>();
         try {
-            return evaluateFeatures(names, attributes, validationTag, SplitResult::treatment);
-        } finally {
-            recordLatency(Method.TREATMENTS_BY_FLAG_SET, start);
+            names = getNamesFromSet(validationTag, Collections.singletonList(flagSet));
+            if (isClientDestroyed) {
+                mValidationLogger.e(CLIENT_DESTROYED_MESSAGE, validationTag);
+                return controlTreatmentsForSplits(new ArrayList<>(names), validationTag);
+            }
+
+            long start = System.currentTimeMillis();
+            try {
+                return evaluateFeatures(names, attributes, validationTag, SplitResult::treatment);
+            } finally {
+                recordLatency(Method.TREATMENTS_BY_FLAG_SET, start);
+            }
+        } catch (Exception exception) {
+            Logger.e("Client getTreatmentsByFlagSet exception", exception);
+            mTelemetryStorageProducer.recordException(Method.TREATMENTS_BY_FLAG_SET);
+
+            return controlTreatmentsForSplits(new ArrayList<>(names), validationTag);
         }
     }
 
     @Override
     public Map<String, String> getTreatmentsByFlagSets(@NonNull List<String> flagSets, @Nullable Map<String, Object> attributes, boolean isClientDestroyed) {
         String validationTag = ValidationTag.GET_TREATMENTS_BY_FLAG_SETS;
-        Set<String> names = getNamesFromSet(validationTag, flagSets);
-        if (isClientDestroyed) {
-            mValidationLogger.e(CLIENT_DESTROYED_MESSAGE, validationTag);
-            return controlTreatmentsForSplits(new ArrayList<>(names), validationTag);
-        }
-
-        long start = System.currentTimeMillis();
+        Set<String> names = new HashSet<>();
         try {
-            return evaluateFeatures(names, attributes, validationTag, SplitResult::treatment);
-        } finally {
-            recordLatency(Method.TREATMENTS_BY_FLAG_SETS, start);
+            names = getNamesFromSet(validationTag, flagSets);
+            if (isClientDestroyed) {
+                mValidationLogger.e(CLIENT_DESTROYED_MESSAGE, validationTag);
+                return controlTreatmentsForSplits(new ArrayList<>(names), validationTag);
+            }
+
+            long start = System.currentTimeMillis();
+            try {
+                return evaluateFeatures(names, attributes, validationTag, SplitResult::treatment);
+            } finally {
+                recordLatency(Method.TREATMENTS_BY_FLAG_SETS, start);
+            }
+        } catch (Exception exception) {
+            Logger.e("Client getTreatmentsByFlagSets exception", exception);
+            mTelemetryStorageProducer.recordException(Method.TREATMENTS_BY_FLAG_SETS);
+
+            return controlTreatmentsForSplits(new ArrayList<>(names), validationTag);
         }
     }
 
     @Override
     public Map<String, SplitResult> getTreatmentsWithConfigByFlagSet(@NonNull String flagSet, @Nullable Map<String, Object> attributes, boolean isClientDestroyed) {
         String validationTag = ValidationTag.GET_TREATMENTS_WITH_CONFIG_BY_FLAG_SET;
-        Set<String> names = getNamesFromSet(validationTag, Collections.singletonList(flagSet));
-        if (isClientDestroyed) {
-            mValidationLogger.e(CLIENT_DESTROYED_MESSAGE, validationTag);
-            return controlTreatmentsForSplitsWithConfig(new ArrayList<>(names), validationTag);
-        }
-
-        long start = System.currentTimeMillis();
+        Set<String> names = new HashSet<>();
         try {
-            return evaluateFeatures(names, attributes, validationTag, ResultTransformer::identity);
-        } finally {
-            recordLatency(Method.TREATMENTS_WITH_CONFIG_BY_FLAG_SET, start);
+            names = getNamesFromSet(validationTag, Collections.singletonList(flagSet));
+            if (isClientDestroyed) {
+                mValidationLogger.e(CLIENT_DESTROYED_MESSAGE, validationTag);
+                return controlTreatmentsForSplitsWithConfig(new ArrayList<>(names), validationTag);
+            }
+
+            long start = System.currentTimeMillis();
+            try {
+                return evaluateFeatures(names, attributes, validationTag, ResultTransformer::identity);
+            } finally {
+                recordLatency(Method.TREATMENTS_WITH_CONFIG_BY_FLAG_SET, start);
+            }
+        } catch (Exception exception) {
+            Logger.e("Client getTreatmentsWithConfigByFlagSet exception", exception);
+            mTelemetryStorageProducer.recordException(Method.TREATMENTS_WITH_CONFIG_BY_FLAG_SET);
+
+            return controlTreatmentsForSplitsWithConfig(new ArrayList<>(names), validationTag);
         }
     }
 
     @Override
     public Map<String, SplitResult> getTreatmentsWithConfigByFlagSets(@NonNull List<String> flagSets, @Nullable Map<String, Object> attributes, boolean isClientDestroyed) {
         String validationTag = ValidationTag.GET_TREATMENTS_WITH_CONFIG_BY_FLAG_SETS;
-        Set<String> names = getNamesFromSet(validationTag, flagSets);
-        if (isClientDestroyed) {
-            mValidationLogger.e(CLIENT_DESTROYED_MESSAGE, validationTag);
-            return controlTreatmentsForSplitsWithConfig(new ArrayList<>(names), validationTag);
-        }
-
-        long start = System.currentTimeMillis();
+        Set<String> names = new HashSet<>();
         try {
-            return evaluateFeatures(names, attributes, validationTag, ResultTransformer::identity);
-        } finally {
-            recordLatency(Method.TREATMENTS_WITH_CONFIG_BY_FLAG_SETS, start);
+            names = getNamesFromSet(validationTag, flagSets);
+            if (isClientDestroyed) {
+                mValidationLogger.e(CLIENT_DESTROYED_MESSAGE, validationTag);
+                return controlTreatmentsForSplitsWithConfig(new ArrayList<>(names), validationTag);
+            }
+
+            long start = System.currentTimeMillis();
+            try {
+                return evaluateFeatures(names, attributes, validationTag, ResultTransformer::identity);
+            } finally {
+                recordLatency(Method.TREATMENTS_WITH_CONFIG_BY_FLAG_SETS, start);
+            }
+        } catch (Exception exception) {
+            Logger.e("Client getTreatmentsWithConfigByFlagSets exception", exception);
+            mTelemetryStorageProducer.recordException(Method.TREATMENTS_WITH_CONFIG_BY_FLAG_SETS);
+
+            return controlTreatmentsForSplitsWithConfig(new ArrayList<>(names), validationTag);
         }
     }
 


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Added calls to treatment manager in `LocalhostSplitClient` and `SplitClientImpl`.
- To avoid keeping a reference to `SplitsStorage` in the client, general exceptions for these methods are being handled in `TreatmentManagerImpl`.