### PR TITLE
Replace exceptions in SplitFactoryBuilder

### DIFF
--- a/src/androidTest/java/tests/integration/TrackTest.java
+++ b/src/androidTest/java/tests/integration/TrackTest.java
@@ -36,6 +36,7 @@ import io.split.android.client.SplitFactoryBuilder;
 import io.split.android.client.api.Key;
 import io.split.android.client.dtos.Event;
 import io.split.android.client.events.SplitEvent;
+import io.split.android.client.exceptions.SplitInstantiationException;
 import io.split.android.client.storage.db.GeneralInfoEntity;
 import io.split.android.client.storage.db.SplitRoomDatabase;
 import okhttp3.mockwebserver.Dispatcher;
@@ -216,7 +217,7 @@ public class TrackTest {
     }
 
     @Test
-    public void largeNumberInPropertiesTest() throws InterruptedException, IOException, URISyntaxException, TimeoutException {
+    public void largeNumberInPropertiesTest() throws InterruptedException, SplitInstantiationException {
         CountDownLatch latch = new CountDownLatch(1);
         String apiKey = IntegrationHelper.dummyApiKey();
         SplitRoomDatabase splitRoomDatabase = DatabaseHelper.getTestDatabase(mContext);

--- a/src/androidTest/java/tests/localhost/LocalhostTest.java
+++ b/src/androidTest/java/tests/localhost/LocalhostTest.java
@@ -58,14 +58,10 @@ public class LocalhostTest {
         SplitManager manager = null;
 
         CountDownLatch readyLatch = new CountDownLatch(1);
-        try {
-            factory = new LocalhostSplitFactory("key", mContext, mSplitClientConfig);
-            client = factory.client();
-            manager = factory.manager();
-            client.on(SplitEvent.SDK_READY, new TestingHelper.TestEventTask(readyLatch));
-
-        } catch (IOException e) {
-        }
+        factory = new LocalhostSplitFactory("key", mContext, mSplitClientConfig);
+        client = factory.client();
+        manager = factory.manager();
+        client.on(SplitEvent.SDK_READY, new TestingHelper.TestEventTask(readyLatch));
 
         readyLatch.await(5, TimeUnit.SECONDS);
 
@@ -158,14 +154,11 @@ public class LocalhostTest {
         SplitManager manager = null;
 
         CountDownLatch readyLatch = new CountDownLatch(1);
-        try {
-            factory = new LocalhostSplitFactory("key", mContext, mSplitClientConfig,"splits_test.properties");
-            client = (LocalhostSplitClient) factory.client();
-            manager = factory.manager();
+        factory = new LocalhostSplitFactory("key", mContext, mSplitClientConfig,"splits_test.properties");
+        client = (LocalhostSplitClient) factory.client();
+        manager = factory.manager();
             client.on(SplitEvent.SDK_READY, new TestingHelper.TestEventTask(readyLatch));
 
-        } catch (IOException e) {
-        }
 
         readyLatch.await(5, TimeUnit.SECONDS);
 
@@ -210,14 +203,11 @@ public class LocalhostTest {
         SplitClient client = null;
         SplitManager manager = null;
         CountDownLatch timeoutLatch = new CountDownLatch(1);
-        try {
-            factory = new LocalhostSplitFactory("key", mContext, mSplitClientConfig, "splits_test_not_found");
-            client = factory.client();
-            manager = factory.manager();
+        factory = new LocalhostSplitFactory("key", mContext, mSplitClientConfig, "splits_test_not_found");
+        client = factory.client();
+        manager = factory.manager();
             client.on(SplitEvent.SDK_READY_TIMED_OUT, new TestingHelper.TestEventTask(timeoutLatch));
 
-        } catch (IOException e) {
-        }
         timeoutLatch.await(5, TimeUnit.SECONDS);
         List<SplitView> splits = manager.splits();
         SplitView sva = manager.split("split_a");
@@ -250,12 +240,9 @@ public class LocalhostTest {
         LocalhostSplitClient client = null;
 
         CountDownLatch readyLatch = new CountDownLatch(1);
-        try {
-            factory = new LocalhostSplitFactory("key", mContext, mSplitClientConfig, "splits_yml.yml");
-            client = (LocalhostSplitClient) factory.client();
-            client.on(SplitEvent.SDK_READY, new TestingHelper.TestEventTask(readyLatch));
-        } catch (IOException e) {
-        }
+        factory = new LocalhostSplitFactory("key", mContext, mSplitClientConfig, "splits_yml.yml");
+        client = (LocalhostSplitClient) factory.client();
+        client.on(SplitEvent.SDK_READY, new TestingHelper.TestEventTask(readyLatch));
         readyLatch.await(5, TimeUnit.SECONDS);
 
         Assert.assertNotNull(factory);

--- a/src/main/java/io/split/android/client/EventsTrackerImpl.java
+++ b/src/main/java/io/split/android/client/EventsTrackerImpl.java
@@ -8,8 +8,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.split.android.client.dtos.Event;
-import io.split.android.client.events.SplitEvent;
-import io.split.android.client.events.SplitEventsManager;
 import io.split.android.client.service.synchronizer.SyncManager;
 import io.split.android.client.telemetry.model.Method;
 import io.split.android.client.telemetry.storage.TelemetryStorageProducer;

--- a/src/main/java/io/split/android/client/FlagSetsFilter.java
+++ b/src/main/java/io/split/android/client/FlagSetsFilter.java
@@ -1,6 +1,4 @@
 package io.split.android.client;
 
-import java.util.Set;
-
 public interface FlagSetsFilter extends FeatureFlagFilter {
 }

--- a/src/main/java/io/split/android/client/SplitClientFactoryImpl.java
+++ b/src/main/java/io/split/android/client/SplitClientFactoryImpl.java
@@ -5,8 +5,6 @@ import static io.split.android.client.utils.Utils.checkNotNull;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import java.util.Set;
-
 import io.split.android.client.api.Key;
 import io.split.android.client.attributes.AttributesManagerFactory;
 import io.split.android.client.attributes.AttributesManagerFactoryImpl;

--- a/src/main/java/io/split/android/client/SplitFactoryBuilder.java
+++ b/src/main/java/io/split/android/client/SplitFactoryBuilder.java
@@ -2,77 +2,96 @@ package io.split.android.client;
 
 import android.content.Context;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.concurrent.TimeoutException;
+import androidx.annotation.NonNull;
 
 import io.split.android.client.api.Key;
+import io.split.android.client.exceptions.SplitInstantiationException;
 import io.split.android.client.localhost.LocalhostSplitFactory;
 import io.split.android.client.service.ServiceConstants;
 
 /**
- * Builds an instance of SplitClient.
+ * Builds an instance of {@link SplitFactory}.
  */
 public class SplitFactoryBuilder {
 
     /**
+     * Instantiates a {@link SplitFactory} with default configurations
      *
-     * @param sdkKey
-     * @param matchingKey
-     * @param context
-     * @return
-     * @throws IOException
-     * @throws InterruptedException
-     * @throws TimeoutException
-     * @throws URISyntaxException
+     * @param sdkKey      the SDK key. MUST NOT be null
+     * @param matchingKey the matching key. MUST NOT be null
+     * @param context     the Android Context. MUST NOT be null
+     * @return a {@link SplitFactory} implementation
+     * @throws SplitInstantiationException
      */
-    public static SplitFactory build(String sdkKey, String matchingKey, Context context) throws IOException, InterruptedException, TimeoutException, URISyntaxException {
+    public static SplitFactory build(@NonNull String sdkKey, @NonNull String matchingKey, @NonNull Context context) throws SplitInstantiationException {
+        if (matchingKey == null) {
+            throw new SplitInstantiationException("Could not instantiate SplitFactory. Matching key cannot be null");
+        }
+
         Key key = new Key(matchingKey, null);
         return build(sdkKey, key, context);
     }
 
     /**
-     * Instantiates a SplitFactory with default configurations
+     * Instantiates a {@link SplitFactory} with default configurations
      *
-     * @param sdkKey the SDK key. MUST NOT be null
-     * @return a SplitFactory
-     * @throws IOException                           if the SDK was being started in 'localhost' mode, but
-     *                                               there were problems reading the override file from disk.
-     * @throws java.lang.InterruptedException        if you asked to block until the sdk was
-     *                                               ready and the block was interrupted.
-     * @throws java.util.concurrent.TimeoutException if you asked to block until the sdk was
-     *                                               ready and the timeout specified via config#ready() passed.
+     * @param sdkKey  the SDK key. MUST NOT be null
+     * @param key     the matching key. MUST NOT be null
+     * @param context the Android Context. MUST NOT be null
+     * @return a {@link SplitFactory} implementation
+     * @throws SplitInstantiationException
      */
-    public static SplitFactory build(String sdkKey, Key key, Context context) throws IOException, InterruptedException, TimeoutException, URISyntaxException {
+    public static SplitFactory build(@NonNull String sdkKey, @NonNull Key key, @NonNull Context context) throws SplitInstantiationException {
         return build(sdkKey, key, SplitClientConfig.builder().build(), context);
     }
 
     /**
-     * @param sdkKey the SDK key. MUST NOT be null
-     * @param config   parameters to control sdk construction. MUST NOT be null.
-     * @return a SplitFactory
-     * @throws java.io.IOException                   if the SDK was being started in 'localhost' mode, but
-     *                                               there were problems reading the override file from disk.
-     * @throws InterruptedException                  if you asked to block until the sdk was
-     *                                               ready and the block was interrupted.
-     * @throws java.util.concurrent.TimeoutException if you asked to block until the sdk was
-     *                                               ready and the timeout specified via config#ready() passed.
+     * Instantiates a {@link SplitFactory}
+     *
+     * @param sdkKey  the SDK key. MUST NOT be null
+     * @param key     the matching key. MUST NOT be null
+     * @param context the Android Context. MUST NOT be null
+     * @return a {@link SplitFactory} implementation
+     * @throws SplitInstantiationException
      */
-    public static synchronized SplitFactory build(String sdkKey, Key key, SplitClientConfig config, Context context) throws IOException, InterruptedException, TimeoutException, URISyntaxException {
-        if (ServiceConstants.LOCALHOST.equals(sdkKey)) {
-            return new LocalhostSplitFactory(key.matchingKey(), context, config);
-        } else {
-            return new SplitFactoryImpl(sdkKey, key, config, context);
+    public static synchronized SplitFactory build(@NonNull String sdkKey, @NonNull Key key, @NonNull SplitClientConfig config, @NonNull Context context) throws SplitInstantiationException {
+        try {
+            checkPreconditions(sdkKey, key, config, context);
+
+            if (ServiceConstants.LOCALHOST.equals(sdkKey)) {
+                return new LocalhostSplitFactory(key.matchingKey(), context, config);
+            } else {
+                return new SplitFactoryImpl(sdkKey, key, config, context);
+            }
+        } catch (Exception ex) {
+            throw new SplitInstantiationException("Could not instantiate SplitFactory", ex);
         }
     }
 
     /**
-     * Instantiates a local Off-The-Grid SplitFactory
+     * Instantiates a local {@link SplitFactory}
      *
-     * @return a SplitFactory
-     * @throws IOException if there were problems reading the override file from disk.
+     * @return a {@link SplitFactory} implementation
      */
-    public static SplitFactory local(String key, Context context) throws IOException {
-        return new LocalhostSplitFactory(key, context, SplitClientConfig.builder().build() );
+    public static SplitFactory local(String key, Context context) {
+        return new LocalhostSplitFactory(key, context, SplitClientConfig.builder().build());
+    }
+
+    private static void checkPreconditions(@NonNull String sdkKey, @NonNull Key key, @NonNull SplitClientConfig config, @NonNull Context context) throws SplitInstantiationException {
+        if (sdkKey == null) {
+            throw new SplitInstantiationException("Could not instantiate SplitFactory. SDK key cannot be null");
+        }
+
+        if (key == null) {
+            throw new SplitInstantiationException("Could not instantiate SplitFactory. Matching key cannot be null");
+        }
+
+        if (config == null) {
+            throw new SplitInstantiationException("Could not instantiate SplitFactory. Config cannot be null");
+        }
+
+        if (context == null) {
+            throw new SplitInstantiationException("Could not instantiate SplitFactory. Context cannot be null");
+        }
     }
 }

--- a/src/main/java/io/split/android/client/SplitFactoryBuilder.java
+++ b/src/main/java/io/split/android/client/SplitFactoryBuilder.java
@@ -73,7 +73,7 @@ public class SplitFactoryBuilder {
      *
      * @return a {@link SplitFactory} implementation
      */
-    public static SplitFactory local(String key, Context context) {
+    public static SplitFactory local(@NonNull String key, @NonNull Context context) {
         return new LocalhostSplitFactory(key, context, SplitClientConfig.builder().build());
     }
 

--- a/src/main/java/io/split/android/client/SplitFactoryBuilder.java
+++ b/src/main/java/io/split/android/client/SplitFactoryBuilder.java
@@ -2,17 +2,13 @@ package io.split.android.client;
 
 import android.content.Context;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.util.concurrent.TimeoutException;
 
 import io.split.android.client.api.Key;
 import io.split.android.client.localhost.LocalhostSplitFactory;
 import io.split.android.client.service.ServiceConstants;
-import io.split.android.client.utils.logger.Logger;
-import io.split.android.grammar.Treatments;
 
 /**
  * Builds an instance of SplitClient.

--- a/src/main/java/io/split/android/client/SplitFactoryBuilder.java
+++ b/src/main/java/io/split/android/client/SplitFactoryBuilder.java
@@ -23,6 +23,7 @@ public class SplitFactoryBuilder {
      * @return a {@link SplitFactory} implementation
      * @throws SplitInstantiationException
      */
+    @NonNull
     public static SplitFactory build(@NonNull String sdkKey, @NonNull String matchingKey, @NonNull Context context) throws SplitInstantiationException {
         if (matchingKey == null) {
             throw new SplitInstantiationException("Could not instantiate SplitFactory. Matching key cannot be null");
@@ -41,6 +42,7 @@ public class SplitFactoryBuilder {
      * @return a {@link SplitFactory} implementation
      * @throws SplitInstantiationException
      */
+    @NonNull
     public static SplitFactory build(@NonNull String sdkKey, @NonNull Key key, @NonNull Context context) throws SplitInstantiationException {
         return build(sdkKey, key, SplitClientConfig.builder().build(), context);
     }
@@ -54,6 +56,7 @@ public class SplitFactoryBuilder {
      * @return a {@link SplitFactory} implementation
      * @throws SplitInstantiationException
      */
+    @NonNull
     public static synchronized SplitFactory build(@NonNull String sdkKey, @NonNull Key key, @NonNull SplitClientConfig config, @NonNull Context context) throws SplitInstantiationException {
         try {
             checkPreconditions(sdkKey, key, config, context);
@@ -73,6 +76,7 @@ public class SplitFactoryBuilder {
      *
      * @return a {@link SplitFactory} implementation
      */
+    @NonNull
     public static SplitFactory local(@NonNull String key, @NonNull Context context) {
         return new LocalhostSplitFactory(key, context, SplitClientConfig.builder().build());
     }

--- a/src/main/java/io/split/android/client/SplitFactoryImpl.java
+++ b/src/main/java/io/split/android/client/SplitFactoryImpl.java
@@ -3,6 +3,7 @@ package io.split.android.client;
 import android.content.Context;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.util.Pair;
 
 import java.net.URISyntaxException;
@@ -79,21 +80,21 @@ public class SplitFactoryImpl implements SplitFactory {
     private final SplitClientContainer mClientContainer;
     private final UserConsentManager mUserConsentManager;
 
-    @SuppressWarnings("FieldCanBeLocal")
+    @SuppressWarnings("FieldCanBeLocal") // keeping the reference on purpose
     private final SplitTaskExecutionListener mMigrationExecutionListener;
 
-    public SplitFactoryImpl(String apiToken, Key key, SplitClientConfig config, Context context)
+    public SplitFactoryImpl(@NonNull String apiToken, @NonNull Key key, @NonNull SplitClientConfig config, @NonNull Context context)
             throws URISyntaxException {
         this(apiToken, key, config, context,
                 null, null, null,
                 null, null, null);
     }
 
-    private SplitFactoryImpl(String apiToken, Key key, SplitClientConfig config,
-                             Context context, HttpClient httpClient, SplitRoomDatabase testDatabase,
-                             SynchronizerSpy synchronizerSpy,
-                             TestingConfig testingConfig, SplitLifecycleManager testLifecycleManager,
-                             TelemetryStorage telemetryStorage)
+    private SplitFactoryImpl(@NonNull String apiToken, @NonNull Key key, @NonNull SplitClientConfig config,
+                             @NonNull Context context, @Nullable HttpClient httpClient, @Nullable SplitRoomDatabase testDatabase,
+                             @Nullable SynchronizerSpy synchronizerSpy,
+                             @Nullable TestingConfig testingConfig, @Nullable SplitLifecycleManager testLifecycleManager,
+                             @Nullable TelemetryStorage telemetryStorage)
             throws URISyntaxException {
 
         mDefaultClientKey = key;

--- a/src/main/java/io/split/android/client/events/SplitEventsManager.java
+++ b/src/main/java/io/split/android/client/events/SplitEventsManager.java
@@ -14,7 +14,6 @@ import io.split.android.client.events.executors.SplitEventExecutor;
 import io.split.android.client.events.executors.SplitEventExecutorFactory;
 import io.split.android.client.events.executors.SplitEventExecutorResources;
 import io.split.android.client.events.executors.SplitEventExecutorResourcesImpl;
-import io.split.android.client.service.executor.SplitClientEventTaskExecutor;
 import io.split.android.client.service.executor.SplitTaskExecutor;
 import io.split.android.client.utils.logger.Logger;
 

--- a/src/main/java/io/split/android/client/exceptions/SplitInstantiationException.java
+++ b/src/main/java/io/split/android/client/exceptions/SplitInstantiationException.java
@@ -1,0 +1,12 @@
+package io.split.android.client.exceptions;
+
+public class SplitInstantiationException extends Exception {
+
+    public SplitInstantiationException(String message) {
+        super(message);
+    }
+
+    public SplitInstantiationException(String message, Exception ex) {
+        super(message, ex);
+    }
+}

--- a/src/main/java/io/split/android/client/localhost/LocalhostSplitFactory.java
+++ b/src/main/java/io/split/android/client/localhost/LocalhostSplitFactory.java
@@ -6,11 +6,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import io.split.android.client.FilterBuilder;
 import io.split.android.client.FlagSetsFilter;

--- a/src/main/java/io/split/android/client/localhost/LocalhostSplitFactory.java
+++ b/src/main/java/io/split/android/client/localhost/LocalhostSplitFactory.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
-import java.io.IOException;
 import java.util.Map;
 
 import io.split.android.client.FilterBuilder;
@@ -51,13 +50,13 @@ public class LocalhostSplitFactory implements SplitFactory {
     private final String mDefaultKey;
     private String mLocalhostFileName = null;
 
-    public LocalhostSplitFactory(String key, Context context, SplitClientConfig config) throws IOException {
+    public LocalhostSplitFactory(String key, Context context, SplitClientConfig config) {
         this(key, context, config, null);
     }
 
     public LocalhostSplitFactory(String key, Context context,
                                  SplitClientConfig config,
-                                 String localhostFileName) throws IOException {
+                                 String localhostFileName) {
 
         if (localhostFileName != null) {
             mLocalhostFileName = localhostFileName;

--- a/src/main/java/io/split/android/client/localhost/LocalhostSplitsStorage.java
+++ b/src/main/java/io/split/android/client/localhost/LocalhostSplitsStorage.java
@@ -43,11 +43,11 @@ public class LocalhostSplitsStorage implements SplitsStorage {
                                   @NonNull Context context,
                                   @NonNull FileStorage fileStorage,
                                   @NonNull EventsManagerCoordinator eventsManager) {
-        this.mLocalhostFileName = fileName;
-        this.mContext = checkNotNull(context);
-        this.mFileStorage = checkNotNull(fileStorage);
-        this.mEventsManager = checkNotNull(eventsManager);
-        this.setup();
+        mLocalhostFileName = fileName;
+        mContext = checkNotNull(context);
+        mFileStorage = checkNotNull(fileStorage);
+        mEventsManager = checkNotNull(eventsManager);
+        setup();
     }
 
     @Override

--- a/src/main/java/io/split/android/client/localhost/LocalhostSynchronizer.java
+++ b/src/main/java/io/split/android/client/localhost/LocalhostSynchronizer.java
@@ -8,7 +8,6 @@ import androidx.annotation.Nullable;
 import javax.security.auth.Destroyable;
 
 import io.split.android.client.SplitClientConfig;
-import io.split.android.client.events.SplitEventsManager;
 import io.split.android.client.lifecycle.SplitLifecycleAware;
 import io.split.android.client.service.executor.SplitTask;
 import io.split.android.client.service.executor.SplitTaskExecutor;

--- a/src/main/java/io/split/android/client/localhost/shared/LocalhostSplitClientContainerImpl.java
+++ b/src/main/java/io/split/android/client/localhost/shared/LocalhostSplitClientContainerImpl.java
@@ -1,7 +1,5 @@
 package io.split.android.client.localhost.shared;
 
-import java.util.Set;
-
 import io.split.android.client.FlagSetsFilter;
 import io.split.android.client.SplitClient;
 import io.split.android.client.SplitClientConfig;

--- a/src/main/java/io/split/android/client/service/CleanUpDatabaseTask.java
+++ b/src/main/java/io/split/android/client/service/CleanUpDatabaseTask.java
@@ -9,7 +9,6 @@ import io.split.android.client.storage.events.PersistentEventsStorage;
 import io.split.android.client.storage.impressions.PersistentImpressionsCountStorage;
 import io.split.android.client.storage.impressions.PersistentImpressionsStorage;
 import io.split.android.client.storage.impressions.PersistentImpressionsUniqueStorage;
-import io.split.android.client.storage.splits.SplitsStorage;
 
 import static io.split.android.client.utils.Utils.checkNotNull;
 

--- a/src/main/java/io/split/android/client/service/impressions/ImpressionsTaskFactory.java
+++ b/src/main/java/io/split/android/client/service/impressions/ImpressionsTaskFactory.java
@@ -6,7 +6,6 @@ import java.util.Set;
 
 import io.split.android.client.service.impressions.unique.SaveUniqueImpressionsTask;
 import io.split.android.client.service.impressions.unique.UniqueKeysRecorderTask;
-import io.split.android.client.service.impressions.unique.UniqueKey;
 
 public interface ImpressionsTaskFactory {
 

--- a/src/main/java/io/split/android/client/service/splits/SplitChangeProcessor.java
+++ b/src/main/java/io/split/android/client/service/splits/SplitChangeProcessor.java
@@ -2,7 +2,6 @@ package io.split.android.client.service.splits;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/io/split/android/client/service/sseclient/EventStreamParser.java
+++ b/src/main/java/io/split/android/client/service/sseclient/EventStreamParser.java
@@ -1,7 +1,5 @@
 package io.split.android.client.service.sseclient;
 
-import androidx.annotation.VisibleForTesting;
-
 import java.util.Map;
 
 public class EventStreamParser {

--- a/src/main/java/io/split/android/client/service/synchronizer/mysegments/MySegmentsSynchronizerRegistryImpl.java
+++ b/src/main/java/io/split/android/client/service/synchronizer/mysegments/MySegmentsSynchronizerRegistryImpl.java
@@ -1,7 +1,5 @@
 package io.split.android.client.service.synchronizer.mysegments;
 
-import androidx.annotation.VisibleForTesting;
-
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/src/main/java/io/split/android/client/service/telemetry/TelemetryTaskFactoryImpl.java
+++ b/src/main/java/io/split/android/client/service/telemetry/TelemetryTaskFactoryImpl.java
@@ -2,10 +2,7 @@ package io.split.android.client.service.telemetry;
 
 import androidx.annotation.NonNull;
 
-import java.util.List;
-
 import io.split.android.client.SplitClientConfig;
-import io.split.android.client.SplitFilter;
 import io.split.android.client.service.http.HttpRecorder;
 import io.split.android.client.storage.mysegments.MySegmentsStorageContainer;
 import io.split.android.client.storage.splits.SplitsStorage;

--- a/src/main/java/io/split/android/client/service/workmanager/SplitsSyncWorker.java
+++ b/src/main/java/io/split/android/client/service/workmanager/SplitsSyncWorker.java
@@ -10,10 +10,8 @@ import androidx.work.WorkerParameters;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 
-import io.split.android.client.FlagSetsFilter;
 import io.split.android.client.FlagSetsFilterImpl;
 import io.split.android.client.SplitFilter;
 import io.split.android.client.dtos.SplitChange;

--- a/src/main/java/io/split/android/client/shared/SplitClientContainerImpl.java
+++ b/src/main/java/io/split/android/client/shared/SplitClientContainerImpl.java
@@ -6,7 +6,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.split.android.client.EventsTracker;

--- a/src/main/java/io/split/android/client/storage/cipher/ApplyCipherTask.java
+++ b/src/main/java/io/split/android/client/storage/cipher/ApplyCipherTask.java
@@ -2,7 +2,6 @@ package io.split.android.client.storage.cipher;
 
 import androidx.annotation.NonNull;
 
-import java.util.Collections;
 import java.util.List;
 
 import io.split.android.client.service.executor.SplitTask;

--- a/src/main/java/io/split/android/client/storage/cipher/EncryptionMigrationTask.java
+++ b/src/main/java/io/split/android/client/storage/cipher/EncryptionMigrationTask.java
@@ -4,9 +4,6 @@ import static io.split.android.client.utils.Utils.checkNotNull;
 
 import androidx.annotation.NonNull;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicReference;
-
 import io.split.android.client.service.executor.SplitTask;
 import io.split.android.client.service.executor.SplitTaskExecutionInfo;
 import io.split.android.client.service.executor.SplitTaskType;

--- a/src/main/java/io/split/android/client/storage/db/EventDao.java
+++ b/src/main/java/io/split/android/client/storage/db/EventDao.java
@@ -4,7 +4,6 @@ import androidx.room.Dao;
 import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
-import androidx.room.Transaction;
 
 import java.util.List;
 

--- a/src/main/java/io/split/android/client/storage/db/ImpressionDao.java
+++ b/src/main/java/io/split/android/client/storage/db/ImpressionDao.java
@@ -1,15 +1,11 @@
 package io.split.android.client.storage.db;
 
 import androidx.room.Dao;
-import androidx.room.Delete;
 import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
-import androidx.room.Update;
 
 import java.util.List;
-
-import io.split.android.client.impressions.Impression;
 
 @Dao
 public interface ImpressionDao {

--- a/src/main/java/io/split/android/client/storage/db/impressions/unique/UniqueKeyEntity.java
+++ b/src/main/java/io/split/android/client/storage/db/impressions/unique/UniqueKeyEntity.java
@@ -4,7 +4,6 @@ import androidx.annotation.NonNull;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
 import androidx.room.Ignore;
-import androidx.room.Index;
 import androidx.room.PrimaryKey;
 
 import io.split.android.client.dtos.Identifiable;

--- a/src/main/java/io/split/android/client/storage/events/EventsStorage.java
+++ b/src/main/java/io/split/android/client/storage/events/EventsStorage.java
@@ -10,7 +10,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.split.android.client.dtos.Event;
-import io.split.android.client.storage.common.PersistentStorage;
 import io.split.android.client.storage.common.Storage;
 import io.split.android.client.storage.common.StoragePusher;
 import io.split.android.client.utils.logger.Logger;

--- a/src/main/java/io/split/android/client/utils/Json.java
+++ b/src/main/java/io/split/android/client/utils/Json.java
@@ -4,10 +4,6 @@ import androidx.annotation.NonNull;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 

--- a/src/main/java/io/split/android/client/utils/Zlib.java
+++ b/src/main/java/io/split/android/client/utils/Zlib.java
@@ -1,6 +1,5 @@
 package io.split.android.client.utils;
 
-import java.io.Closeable;
 import java.util.Arrays;
 import java.util.zip.Inflater;
 

--- a/src/main/java/io/split/android/client/validators/TreatmentManagerFactory.java
+++ b/src/main/java/io/split/android/client/validators/TreatmentManagerFactory.java
@@ -2,9 +2,7 @@ package io.split.android.client.validators;
 
 import io.split.android.client.api.Key;
 import io.split.android.client.attributes.AttributesManager;
-import io.split.android.client.events.ISplitEventsManager;
 import io.split.android.client.events.ListenableEventsManager;
-import io.split.android.client.storage.mysegments.MySegmentsStorage;
 
 public interface TreatmentManagerFactory {
 

--- a/src/main/java/io/split/android/engine/matchers/MySegmentsMatcher.java
+++ b/src/main/java/io/split/android/engine/matchers/MySegmentsMatcher.java
@@ -1,11 +1,9 @@
 package io.split.android.engine.matchers;
 
 import java.util.Map;
-import java.util.Set;
 
 import io.split.android.client.Evaluator;
 import io.split.android.client.storage.mysegments.MySegmentsStorage;
-import io.split.android.client.storage.mysegments.MySegmentsStorageContainer;
 
 /**
  * Created by guillermo on 12/12/17.


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Replaced the exceptions thrown by the `build` methods in `SplitFactoryBuilder`.
- Changed the nullability of parameters for the `build` method. In Kotlin, using nullable arguments now result in a compilation error.