### PR TITLE
Update instrumented tests workflow

### DIFF
--- a/.github/workflows/instrumented.yml
+++ b/.github/workflows/instrumented.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -18,6 +18,12 @@ jobs:
         shard: [ 0, 1, 2, 3 ]
 
     steps:
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/instrumented.yml
+++ b/.github/workflows/instrumented.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/gradle-build-action@v2
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3
@@ -48,7 +48,7 @@ jobs:
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2.28.0
+        uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           avd-name: macOS-avd-arm64-v8a-29


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Applying an update to the instrumented tests workflow since it is now [encouraged](https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners) to run `android-emulator-runner` in `ubuntu-latest` instead of `macos`.