### PR TITLE
LRU cache with listener

### DIFF
--- a/.github/workflows/instrumented.yml
+++ b/.github/workflows/instrumented.yml
@@ -25,13 +25,13 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/gradle-build-action@v3
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 11

--- a/src/androidTest/java/io/split/android/client/service/impressions/observer/ListenableLruCacheTest.java
+++ b/src/androidTest/java/io/split/android/client/service/impressions/observer/ListenableLruCacheTest.java
@@ -1,0 +1,52 @@
+package io.split.android.client.service.impressions.observer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ListenableLruCacheTest {
+
+    @Test
+    public void nullRemovalListenerIsAllowed() {
+        ListenableLruCache<Long, Long> cache = new ListenableLruCache<>(3, null);
+
+        for (int i = 1; i < 5; i++) {
+            cache.put((long) i, (long) i);
+        }
+
+        assertEquals(1, cache.evictionCount());
+    }
+
+    @Test
+    public void removalListenerIsCalledWhenEvictionHappens() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(2);
+        AtomicInteger removedCount = new AtomicInteger();
+        List<Long> removedKeys = new ArrayList<Long>();
+        ListenableLruCache.RemovalListener<Long> listener = key -> {
+            removedKeys.add(key);
+            removedCount.incrementAndGet();
+            latch.countDown();
+        };
+        ListenableLruCache<Long, Long> cache = new ListenableLruCache<>(3, listener);
+
+        for (int i = 1; i < 6; i++) {
+            cache.put((long) i, (long) i);
+        }
+
+        boolean await = latch.await(1, TimeUnit.SECONDS);
+
+        assertEquals(2, cache.evictionCount());
+        assertEquals(1L, removedKeys.get(0).longValue());
+        assertEquals(2L, removedKeys.get(1).longValue());
+
+        assertEquals(2, removedCount.get());
+        assertTrue(await);
+    }
+}

--- a/src/main/java/io/split/android/client/service/impressions/observer/ListenableLruCache.java
+++ b/src/main/java/io/split/android/client/service/impressions/observer/ListenableLruCache.java
@@ -4,6 +4,15 @@ import android.util.LruCache;
 
 import androidx.annotation.Nullable;
 
+/**
+ * Extension of {@link LruCache} that allows to listen to cache evictions.
+ * <p>
+ * The listener is notified when an entry is evicted from the cache by informing the key of the
+ * evicted entry.
+ *
+ * @param <K> Key type
+ * @param <V> Value type
+ */
 class ListenableLruCache<K, V> extends LruCache<K, V> {
 
     private final RemovalListener<K> mRemovalListener;
@@ -21,8 +30,18 @@ class ListenableLruCache<K, V> extends LruCache<K, V> {
         }
     }
 
+    /**
+     * Listener to be notified when an entry is evicted from the cache.
+     *
+     * @param <T> Key type
+     */
     interface RemovalListener<T> {
 
+        /**
+         * Called when an entry is evicted from the cache.
+         *
+         * @param key The key of the evicted entry
+         */
         void onRemoval(T key);
     }
 }

--- a/src/main/java/io/split/android/client/service/impressions/observer/ListenableLruCache.java
+++ b/src/main/java/io/split/android/client/service/impressions/observer/ListenableLruCache.java
@@ -1,0 +1,28 @@
+package io.split.android.client.service.impressions.observer;
+
+import android.util.LruCache;
+
+import androidx.annotation.Nullable;
+
+class ListenableLruCache<K, V> extends LruCache<K, V> {
+
+    private final RemovalListener<K> mRemovalListener;
+
+    public ListenableLruCache(int maxSize, @Nullable RemovalListener<K> removalListener) {
+        super(maxSize);
+        mRemovalListener = removalListener;
+    }
+
+    @Override
+    protected void entryRemoved(boolean evicted, K key, V oldValue, V newValue) {
+        super.entryRemoved(evicted, key, oldValue, newValue);
+        if (mRemovalListener != null && evicted) {
+            mRemovalListener.onRemoval(key);
+        }
+    }
+
+    interface RemovalListener<T> {
+
+        void onRemoval(T key);
+    }
+}


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Added extension of LRU cache that allows to set a listener to be informed of evictions.