### PR TITLE
Default conditions in SplitParser

### DIFF
--- a/src/main/java/io/split/android/client/dtos/MatcherType.java
+++ b/src/main/java/io/split/android/client/dtos/MatcherType.java
@@ -1,31 +1,50 @@
 package io.split.android.client.dtos;
 
+import com.google.gson.annotations.SerializedName;
+
 public enum MatcherType {
+    @SerializedName("ALL_KEYS")
     ALL_KEYS,
+    @SerializedName("IN_SEGMENT")
     IN_SEGMENT,
+    @SerializedName("WHITELIST")
     WHITELIST,
 
     /* Numeric Matcher */
+    @SerializedName("EQUAL_TO")
     EQUAL_TO,
+    @SerializedName("GREATER_THAN_OR_EQUAL_TO")
     GREATER_THAN_OR_EQUAL_TO,
+    @SerializedName("LESS_THAN_OR_EQUAL_TO")
     LESS_THAN_OR_EQUAL_TO,
+    @SerializedName("BETWEEN")
     BETWEEN,
 
     /* Set Matcher */
+    @SerializedName("EQUAL_TO_SET")
     EQUAL_TO_SET,
+    @SerializedName("CONTAINS_ANY_OF_SET")
     CONTAINS_ANY_OF_SET,
+    @SerializedName("CONTAINS_ALL_OF_SET")
     CONTAINS_ALL_OF_SET,
+    @SerializedName("PART_OF_SET")
     PART_OF_SET,
 
     /* String Matcher */
+    @SerializedName("STARTS_WITH")
     STARTS_WITH,
+    @SerializedName("ENDS_WITH")
     ENDS_WITH,
+    @SerializedName("CONTAINS_STRING")
     CONTAINS_STRING,
+    @SerializedName("MATCHES_STRING")
     MATCHES_STRING,
 
     /* Boolean Matcher */
+    @SerializedName("EQUAL_TO_BOOLEAN")
     EQUAL_TO_BOOLEAN,
 
     /* Dependency Matcher */
+    @SerializedName("IN_SPLIT_TREATMENT")
     IN_SPLIT_TREATMENT
 }

--- a/src/main/java/io/split/android/engine/experiments/SplitParser.java
+++ b/src/main/java/io/split/android/engine/experiments/SplitParser.java
@@ -135,6 +135,12 @@ public class SplitParser {
 
     private AttributeMatcher toMatcher(Matcher matcher, String matchingKey) throws UnsupportedMatcherException {
         io.split.android.engine.matchers.Matcher delegate;
+
+        // Values not present in {@link io.split.android.client.dtos.MatcherType} are deserialized as null
+        if (matcher.matcherType == null) {
+            throw new UnsupportedMatcherException("Unable to create matcher for matcher type");
+        }
+
         switch (matcher.matcherType) {
             case ALL_KEYS:
                 delegate = new AllKeysMatcher();
@@ -208,6 +214,8 @@ public class SplitParser {
                 delegate = new BooleanMatcher(matcher.booleanMatcherData);
                 break;
             default:
+                // since values not present in {@link io.split.android.client.dtos.MatcherType}
+                // are deserialized as null, this would most likely not be reached. Adding it for completeness
                 throw new UnsupportedMatcherException("Unable to create matcher for matcher type: " + matcher.matcherType);
         }
 

--- a/src/main/java/io/split/android/engine/experiments/SplitParser.java
+++ b/src/main/java/io/split/android/engine/experiments/SplitParser.java
@@ -3,7 +3,9 @@ package io.split.android.engine.experiments;
 import static io.split.android.client.utils.Utils.checkArgument;
 import static io.split.android.client.utils.Utils.checkNotNull;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,13 +44,21 @@ public class SplitParser {
     public static final int CONDITIONS_UPPER_LIMIT = 50;
 
     private final MySegmentsStorageContainer mMySegmentsStorageContainer;
+    private final DefaultConditionsProvider mDefaultConditionsProvider;
 
-    public static SplitParser get(MySegmentsStorageContainer mySegmentsStorageContainer) {
+    public SplitParser(@NonNull MySegmentsStorageContainer mySegmentsStorageContainer) {
+        this(mySegmentsStorageContainer, new DefaultConditionsProvider());
+    }
+
+    @VisibleForTesting
+    static SplitParser get(MySegmentsStorageContainer mySegmentsStorageContainer) {
         return new SplitParser(mySegmentsStorageContainer);
     }
 
-    public SplitParser(MySegmentsStorageContainer mySegmentsStorageContainer) {
+    @VisibleForTesting
+    SplitParser(@NonNull MySegmentsStorageContainer mySegmentsStorageContainer, @NonNull DefaultConditionsProvider defaultConditionsProvider) {
         mMySegmentsStorageContainer = checkNotNull(mySegmentsStorageContainer);
+        mDefaultConditionsProvider = checkNotNull(defaultConditionsProvider);
     }
 
     @Nullable
@@ -83,10 +93,15 @@ public class SplitParser {
 
         List<ParsedCondition> parsedConditionList = new ArrayList<>();
 
-        for (Condition condition : split.conditions) {
-            List<Partition> partitions = condition.partitions;
-            CombiningMatcher matcher = toMatcher(condition.matcherGroup, matchingKey);
-            parsedConditionList.add(new ParsedCondition(condition.conditionType, matcher, partitions, condition.label));
+        try {
+            for (Condition condition : split.conditions) {
+                List<Partition> partitions = condition.partitions;
+                CombiningMatcher matcher = toMatcher(condition.matcherGroup, matchingKey);
+                parsedConditionList.add(new ParsedCondition(condition.conditionType, matcher, partitions, condition.label));
+            }
+        } catch (UnsupportedMatcherException e) {
+            Logger.w(e.getMessage());
+            parsedConditionList = mDefaultConditionsProvider.getDefaultConditions();
         }
 
         return new ParsedSplit(split.name,
@@ -103,20 +118,22 @@ public class SplitParser {
                 split.sets);
     }
 
-    private CombiningMatcher toMatcher(MatcherGroup matcherGroup, String matchingKey) {
+    private CombiningMatcher toMatcher(MatcherGroup matcherGroup, String matchingKey) throws UnsupportedMatcherException {
         List<Matcher> matchers = matcherGroup.matchers;
         checkArgument(!matchers.isEmpty());
 
         List<AttributeMatcher> toCombine = new ArrayList<>();
 
         for (Matcher matcher : matchers) {
-            toCombine.add(toMatcher(matcher, matchingKey));
+            AttributeMatcher attributeMatcher = toMatcher(matcher, matchingKey);
+
+            toCombine.add(attributeMatcher);
         }
 
         return new CombiningMatcher(matcherGroup.combiner, toCombine);
     }
 
-    private AttributeMatcher toMatcher(Matcher matcher, String matchingKey) {
+    private AttributeMatcher toMatcher(Matcher matcher, String matchingKey) throws UnsupportedMatcherException {
         io.split.android.engine.matchers.Matcher delegate;
         switch (matcher.matcherType) {
             case ALL_KEYS:
@@ -191,10 +208,8 @@ public class SplitParser {
                 delegate = new BooleanMatcher(matcher.booleanMatcherData);
                 break;
             default:
-                throw new IllegalArgumentException("Unknown matcher type: " + matcher.matcherType);
+                throw new UnsupportedMatcherException("Unable to create matcher for matcher type: " + matcher.matcherType);
         }
-
-        checkNotNull(delegate, "We were not able to create a matcher for: " + matcher.matcherType);
 
         String attribute = null;
         if (matcher.keySelector != null && matcher.keySelector.attribute != null) {

--- a/src/main/java/io/split/android/engine/experiments/UnsupportedMatcherException.java
+++ b/src/main/java/io/split/android/engine/experiments/UnsupportedMatcherException.java
@@ -1,0 +1,12 @@
+package io.split.android.engine.experiments;
+
+class UnsupportedMatcherException extends Exception {
+
+    UnsupportedMatcherException(String message) {
+        super(message);
+    }
+
+    UnsupportedMatcherException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/io/split/android/engine/experiments/UnsupportedMatcherSplitParserTest.java
+++ b/src/test/java/io/split/android/engine/experiments/UnsupportedMatcherSplitParserTest.java
@@ -1,0 +1,59 @@
+package io.split.android.engine.experiments;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Collections;
+
+import io.split.android.client.dtos.Split;
+import io.split.android.client.storage.mysegments.MySegmentsStorage;
+import io.split.android.client.storage.mysegments.MySegmentsStorageContainer;
+import io.split.android.client.utils.Json;
+
+public class UnsupportedMatcherSplitParserTest {
+
+    @Mock
+    private MySegmentsStorage mMySegmentsStorage;
+    @Mock
+    private MySegmentsStorageContainer mMySegmentsStorageContainer;
+    @Mock
+    private DefaultConditionsProvider mDefaultConditionsProvider;
+    private final Split mTestFlag = Json.fromJson("{\"changeNumber\":1709843458770,\"trafficTypeName\":\"user\",\"name\":\"feature_flag_for_test\",\"trafficAllocation\":100,\"trafficAllocationSeed\":-1364119282,\"seed\":-605938843,\"status\":\"ACTIVE\",\"killed\":false,\"defaultTreatment\":\"off\",\"algo\":2,\"conditions\":[{\"conditionType\":\"ROLLOUT\",\"matcherGroup\":{\"combiner\":\"AND\",\"matchers\":[{\"keySelector\":{\"trafficType\":\"user\",\"attribute\":null},\"matcherType\":\"WRONG_MATCHER_TYPE\",\"negate\":false,\"userDefinedSegmentMatcherData\":null,\"whitelistMatcherData\":null,\"unaryNumericMatcherData\":null,\"betweenMatcherData\":null,\"dependencyMatcherData\":null,\"booleanMatcherData\":null,\"stringMatcherData\":\"123123\"}]},\"partitions\":[{\"treatment\":\"on\",\"size\":0},{\"treatment\":\"off\",\"size\":100}],\"label\":\"wrong matcher type\"},{\"conditionType\":\"ROLLOUT\",\"matcherGroup\":{\"combiner\":\"AND\",\"matchers\":[{\"keySelector\":{\"trafficType\":\"user\",\"attribute\":\"sem\"},\"matcherType\":\"MATCHES_STRING\",\"negate\":false,\"userDefinedSegmentMatcherData\":null,\"whitelistMatcherData\":null,\"unaryNumericMatcherData\":null,\"betweenMatcherData\":null,\"dependencyMatcherData\":null,\"booleanMatcherData\":null,\"stringMatcherData\":\"1.2.3\"}]},\"partitions\":[{\"treatment\":\"on\",\"size\":100},{\"treatment\":\"off\",\"size\":0}],\"label\":\"sem matches 1.2.3\"}],\"configurations\":{},\"sets\":[]}", Split.class);
+    private AutoCloseable mAutoCloseable;
+    private SplitParser mSplitParser;
+
+    @Before
+    public void setUp() {
+        mAutoCloseable = MockitoAnnotations.openMocks(this);
+        when(mMySegmentsStorageContainer.getStorageForKey("")).thenReturn(mMySegmentsStorage);
+        when(mMySegmentsStorage.getAll()).thenReturn(Collections.emptySet());
+        when(mDefaultConditionsProvider.getDefaultConditions()).thenReturn(Collections.emptyList());
+        mSplitParser = new SplitParser(mMySegmentsStorageContainer, mDefaultConditionsProvider);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        mAutoCloseable.close();
+    }
+
+    @Test
+    public void parsingFeatureFlagWithUnsupportedMatcherDoesNotReturnNull() {
+        ParsedSplit parsedSplit = mSplitParser.parse(mTestFlag);
+
+        assertNotNull(parsedSplit);
+    }
+
+    @Test
+    public void parsingFeatureFlagWithUnsupportedMatcherUsesDefaultConditionsProvider() {
+        mSplitParser.parse(mTestFlag);
+
+        verify(mDefaultConditionsProvider).getDefaultConditions();
+    }
+}


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Added `UnsupportedMatcherException` for cases when the SDK doesn't know the matcher being parsed.
- When an `UnsupportedMatcherException` is caught, a default conditions list is used instead of the original one.
- (Unrelated) added `@SerializedName` annotation for extra safety when using minification.