### PR TITLE
Flags spec in request

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 apply plugin: 'kotlin-android'
+apply from: 'spec.gradle'
 
 ext {
     splitVersion = '4.0.1'
@@ -74,9 +75,11 @@ android {
     buildTypes {
         debug {
             buildConfigField("String", "SPLIT_VERSION_NAME", "\"${splitVersion}\"")
+            buildConfigField("String", "FLAGS_SPEC", "\"${flagsSpec}\"")
         }
         release {
             buildConfigField("String", "SPLIT_VERSION_NAME", "\"${splitVersion}\"")
+            buildConfigField("String", "FLAGS_SPEC", "\"${flagsSpec}\"")
         }
     }
     namespace 'io.split.android.android_client'

--- a/spec.gradle
+++ b/spec.gradle
@@ -1,0 +1,5 @@
+ext {
+
+    // flags spec contains a String with the feature flags specification
+    flagsSpec = '1.1'
+}

--- a/src/androidTest/java/helper/IntegrationHelper.java
+++ b/src/androidTest/java/helper/IntegrationHelper.java
@@ -326,7 +326,7 @@ public class IntegrationHelper {
                                     String body);
 
         static String getSinceFromUri(URI uri) {
-            return uri.getQuery().split("&")[0].split("=")[1];
+            return uri.getQuery().split("&")[1].split("=")[1];
         }
     }
 

--- a/src/androidTest/java/tests/integration/FlagsSpecInRequestTest.java
+++ b/src/androidTest/java/tests/integration/FlagsSpecInRequestTest.java
@@ -1,0 +1,106 @@
+package tests.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static helper.IntegrationHelper.ResponseClosure.getSinceFromUri;
+
+import android.content.Context;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import fake.HttpClientMock;
+import fake.HttpResponseMock;
+import fake.HttpResponseMockDispatcher;
+import helper.DatabaseHelper;
+import helper.FileHelper;
+import helper.IntegrationHelper;
+import helper.TestableSplitConfigBuilder;
+import io.split.android.android_client.test.BuildConfig;
+import io.split.android.client.SplitClient;
+import io.split.android.client.SplitFactory;
+import io.split.android.client.dtos.SplitChange;
+import io.split.android.client.events.SplitEvent;
+import io.split.android.client.storage.db.SplitRoomDatabase;
+import io.split.android.client.utils.Json;
+import tests.integration.shared.TestingHelper;
+
+public class FlagsSpecInRequestTest {
+
+    private final Context mContext = InstrumentationRegistry.getInstrumentation().getContext();
+    private AtomicInteger mImpressionsListenerCount;
+    private HttpClientMock mHttpClient;
+    private SplitRoomDatabase mDatabase;
+    private AtomicReference<String> mQueryString;
+
+    @Before
+    public void setUp() throws IOException {
+        mImpressionsListenerCount = new AtomicInteger(0);
+        mDatabase = DatabaseHelper.getTestDatabase(mContext);
+        mDatabase.clearAllTables();
+        mQueryString = new AtomicReference<>();
+        mHttpClient = new HttpClientMock(getDispatcher());
+    }
+
+    @Test
+    public void queryStringContainsFlagsSpec() throws InterruptedException {
+        String expectedFlagsSpec = BuildConfig.FLAGS_SPEC;
+        initSplitFactory(new TestableSplitConfigBuilder(), mHttpClient);
+
+        assertEquals("s="+expectedFlagsSpec+"&since=-1", mQueryString.get());
+    }
+
+    private HttpResponseMockDispatcher getDispatcher() {
+        Map<String, IntegrationHelper.ResponseClosure> responses = new HashMap<>();
+        responses.put("splitChanges", (uri, httpMethod, body) -> {
+            String queryString = uri.getQuery();
+            mQueryString.set(queryString);
+            String since = getSinceFromUri(uri);
+            if (since.equals("-1")) {
+                return new HttpResponseMock(200, loadSplitChanges());
+            } else {
+                return new HttpResponseMock(200, IntegrationHelper.emptySplitChanges(1602796638344L, 1602796638344L));
+            }
+        });
+
+        responses.put("mySegments/CUSTOMER_ID", (uri, httpMethod, body) -> new HttpResponseMock(200, IntegrationHelper.emptyMySegments()));
+
+        return IntegrationHelper.buildDispatcher(responses);
+    }
+
+    private void initSplitFactory(TestableSplitConfigBuilder builder, HttpClientMock httpClient) throws InterruptedException {
+        CountDownLatch innerLatch = new CountDownLatch(1);
+        SplitFactory factory = IntegrationHelper.buildFactory(
+                "sdk_key_1",
+                IntegrationHelper.dummyUserKey(),
+                builder.build(),
+                mContext,
+                httpClient,
+                mDatabase);
+
+        SplitClient client = factory.client();
+        client.on(SplitEvent.SDK_READY, new TestingHelper.TestEventTask(innerLatch));
+        boolean await = innerLatch.await(5, TimeUnit.SECONDS);
+        if (!await) {
+            fail("Client is not ready");
+        }
+    }
+
+    private String loadSplitChanges() {
+        FileHelper fileHelper = new FileHelper();
+        String change = fileHelper.loadFileContent(mContext, "split_changes_1.json");
+        SplitChange parsedChange = Json.fromJson(change, SplitChange.class);
+        parsedChange.since = parsedChange.till;
+        return Json.toJson(parsedChange);
+    }
+}

--- a/src/androidTest/java/tests/integration/InitialChangeNumberTest.java
+++ b/src/androidTest/java/tests/integration/InitialChangeNumberTest.java
@@ -1,5 +1,7 @@
 package tests.integration;
 
+import static helper.IntegrationHelper.ResponseClosure.getSinceFromUri;
+
 import android.content.Context;
 
 import androidx.core.util.Pair;
@@ -21,7 +23,6 @@ import io.split.android.client.ServiceEndpoints;
 import io.split.android.client.SplitClient;
 import io.split.android.client.SplitClientConfig;
 import io.split.android.client.SplitFactory;
-import io.split.android.client.SplitFactoryBuilder;
 import io.split.android.client.api.Key;
 import io.split.android.client.events.SplitEvent;
 import io.split.android.client.storage.db.GeneralInfoEntity;
@@ -68,7 +69,7 @@ public class InitialChangeNumberTest {
                     long changeNumber = -1;
                     if (mIsFirstChangeNumber) {
                         String path = request.getPath();
-                        changeNumber = Long.valueOf(path.substring(path.indexOf("=") + 1));
+                        changeNumber = Long.parseLong(getSinceFromUri(request.getRequestUrl().uri()));
                         mFirstChangeNumberReceived = changeNumber;
                         mIsFirstChangeNumber = false;
                     }

--- a/src/androidTest/java/tests/integration/SplitFetchSpecificSplitTest.java
+++ b/src/androidTest/java/tests/integration/SplitFetchSpecificSplitTest.java
@@ -144,7 +144,7 @@ public class SplitFetchSpecificSplitTest {
 
         latch.await(10, TimeUnit.SECONDS);
 
-        Assert.assertEquals("since=2" + expectedQs, mReceivedQueryString);
+        Assert.assertEquals("s=1.1&since=2" + expectedQs, mReceivedQueryString);
 
         splitFactory.destroy();
     }

--- a/src/androidTest/java/tests/integration/SplitsTwoDifferentApiKeyTest.java
+++ b/src/androidTest/java/tests/integration/SplitsTwoDifferentApiKeyTest.java
@@ -2,6 +2,8 @@ package tests.integration;
 
 import static java.lang.Thread.sleep;
 
+import static helper.IntegrationHelper.ResponseClosure.getSinceFromUri;
+
 import android.content.Context;
 
 import androidx.test.platform.app.InstrumentationRegistry;
@@ -173,7 +175,7 @@ public class SplitsTwoDifferentApiKeyTest {
                     return createResponse(200, IntegrationHelper.dummyMySegments());
                 } else if (uri.getPath().contains("/splitChanges")) {
                     int hit = 0;
-                    long changeNumber = new Integer(uri.getQuery().split("=")[1]);
+                    long changeNumber = Long.parseLong(getSinceFromUri(uri));//new Integer(uri.getQuery().split("&")[1].split("=")[1]);
                     if (factoryNumber == 1) {
                         System.out.println("hit 1 cn: " + changeNumber);
                         f1ChangeNumbers.add(changeNumber);

--- a/src/androidTest/java/tests/integration/sets/FlagSetsPollingTest.java
+++ b/src/androidTest/java/tests/integration/sets/FlagSetsPollingTest.java
@@ -169,7 +169,7 @@ public class FlagSetsPollingTest {
         String uri = mSplitChangesUri;
 
         assertTrue(awaitFirst);
-        assertEquals("https://sdk.split.io/api/splitChanges?since=-1&sets=set_2,set_3,set_ww,set_x", uri);
+        assertEquals("https://sdk.split.io/api/splitChanges?s=1.1&since=-1&sets=set_2,set_3,set_ww,set_x", uri);
     }
 
     private SplitFactory createFactory(

--- a/src/androidTest/java/tests/integration/streaming/SplitsKillProcessTest.java
+++ b/src/androidTest/java/tests/integration/streaming/SplitsKillProcessTest.java
@@ -42,6 +42,7 @@ import io.split.android.client.utils.logger.Logger;
 import tests.integration.shared.TestingHelper;
 
 import static java.lang.Thread.sleep;
+import static helper.IntegrationHelper.ResponseClosure.getSinceFromUri;
 
 public class SplitsKillProcessTest {
     Context mContext;
@@ -175,7 +176,7 @@ public class SplitsKillProcessTest {
                 } else if (uri.getPath().contains("/splitChanges")) {
 
                     mSplitChangesHitCount++;
-                    mLastChangeNumber = new Integer(uri.getQuery().split("=")[1]);
+                    mLastChangeNumber = Long.parseLong(getSinceFromUri(uri));
                     Logger.i("** Split Changes hit p: " + mLastChangeNumber);
                     mSplitsSyncLatch.countDown();
                     if (mSplitChangesHitCount > 2) {

--- a/src/androidTest/java/tests/integration/streaming/SplitsSyncProcessTest.java
+++ b/src/androidTest/java/tests/integration/streaming/SplitsSyncProcessTest.java
@@ -41,6 +41,7 @@ import io.split.android.client.utils.logger.Logger;
 import tests.integration.shared.TestingHelper;
 
 import static java.lang.Thread.sleep;
+import static helper.IntegrationHelper.ResponseClosure.getSinceFromUri;
 
 public class SplitsSyncProcessTest {
     Context mContext;
@@ -165,7 +166,7 @@ public class SplitsSyncProcessTest {
                 } else if (uri.getPath().contains("/splitChanges")) {
 
                     mSplitChangesHitCount++;
-                    mLastChangeNumber = new Integer(uri.getQuery().split("=")[1]);
+                    mLastChangeNumber = Long.parseLong(getSinceFromUri(uri));
                     Logger.i("** Split Changes hit p: " + mLastChangeNumber);
                     mSplitsSyncLatch.countDown();
                     if (mSplitChangesHitCount > 2) {

--- a/src/main/java/io/split/android/client/network/URIBuilder.java
+++ b/src/main/java/io/split/android/client/network/URIBuilder.java
@@ -7,7 +7,7 @@ import androidx.core.util.Pair;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import io.split.android.client.utils.Utils;
@@ -31,7 +31,7 @@ public class URIBuilder {
         } else {
             mPath = path;
         }
-        mParams = new HashSet<>();
+        mParams = new LinkedHashSet<>();
     }
 
     public URIBuilder(@NonNull URI rootURI) {

--- a/src/main/java/io/split/android/client/service/splits/SplitsSyncHelper.java
+++ b/src/main/java/io/split/android/client/service/splits/SplitsSyncHelper.java
@@ -156,7 +156,10 @@ public class SplitsSyncHelper {
 
     private SplitChange fetchSplits(long till, boolean avoidCache, boolean withCdnByPass) throws HttpFetcherException {
         Map<String, Object> params = new LinkedHashMap<>();
-        params.put(FLAGS_SPEC_PARAM, BuildConfig.FLAGS_SPEC);
+        String flagsSpec = BuildConfig.FLAGS_SPEC;
+        if (flagsSpec != null) {
+            params.put(FLAGS_SPEC_PARAM, flagsSpec);
+        }
         params.put(SINCE_PARAM, till);
 
         if (withCdnByPass) {

--- a/src/main/java/io/split/android/client/service/splits/SplitsSyncHelper.java
+++ b/src/main/java/io/split/android/client/service/splits/SplitsSyncHelper.java
@@ -7,7 +7,6 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -32,7 +31,7 @@ public class SplitsSyncHelper {
 
     private static final String SINCE_PARAM = "since";
     private static final String TILL_PARAM = "till";
-    private static final String SPEC_PARAM = "s";
+    private static final String FLAGS_SPEC_PARAM = "s";
     private static final int ON_DEMAND_FETCH_BACKOFF_MAX_RETRIES = 10;
     private static final int ON_DEMAND_FETCH_BACKOFF_MAX_WAIT = ServiceConstants.ON_DEMAND_FETCH_BACKOFF_MAX_WAIT;
 
@@ -157,7 +156,7 @@ public class SplitsSyncHelper {
 
     private SplitChange fetchSplits(long till, boolean avoidCache, boolean withCdnByPass) throws HttpFetcherException {
         Map<String, Object> params = new LinkedHashMap<>();
-        params.put(SPEC_PARAM, BuildConfig.FLAGS_SPEC);
+        params.put(FLAGS_SPEC_PARAM, BuildConfig.FLAGS_SPEC);
         params.put(SINCE_PARAM, till);
 
         if (withCdnByPass) {

--- a/src/main/java/io/split/android/client/service/splits/SplitsSyncHelper.java
+++ b/src/main/java/io/split/android/client/service/splits/SplitsSyncHelper.java
@@ -8,9 +8,11 @@ import androidx.annotation.VisibleForTesting;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import io.split.android.android_client.BuildConfig;
 import io.split.android.client.dtos.SplitChange;
 import io.split.android.client.network.SplitHttpHeadersBuilder;
 import io.split.android.client.service.ServiceConstants;
@@ -30,6 +32,7 @@ public class SplitsSyncHelper {
 
     private static final String SINCE_PARAM = "since";
     private static final String TILL_PARAM = "till";
+    private static final String SPEC_PARAM = "s";
     private static final int ON_DEMAND_FETCH_BACKOFF_MAX_RETRIES = 10;
     private static final int ON_DEMAND_FETCH_BACKOFF_MAX_WAIT = ServiceConstants.ON_DEMAND_FETCH_BACKOFF_MAX_WAIT;
 
@@ -153,7 +156,8 @@ public class SplitsSyncHelper {
     }
 
     private SplitChange fetchSplits(long till, boolean avoidCache, boolean withCdnByPass) throws HttpFetcherException {
-        Map<String, Object> params = new HashMap<>();
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put(SPEC_PARAM, BuildConfig.FLAGS_SPEC);
         params.put(SINCE_PARAM, till);
 
         if (withCdnByPass) {

--- a/src/test/java/io/split/android/client/service/SplitsSyncHelperTest.java
+++ b/src/test/java/io/split/android/client/service/SplitsSyncHelperTest.java
@@ -4,12 +4,14 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import io.split.android.client.dtos.SplitChange;
@@ -31,6 +33,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
@@ -364,6 +367,20 @@ public class SplitsSyncHelperTest {
         SplitTaskExecutionInfo result = mSplitsSyncHelper.sync(-1);
 
         assertNull(result.getBoolValue(SplitTaskExecutionInfo.DO_NOT_RETRY));
+    }
+
+    @Test
+    public void defaultQueryParamOrderIsCorrect() throws HttpFetcherException {
+        mSplitsSyncHelper.sync(100);
+
+        verify(mSplitsFetcher).execute(argThat(new ArgumentMatcher<Map<String, Object>>() {
+            @Override
+            public boolean matches(Map<String, Object> argument) {
+                List<String> keys = new ArrayList<>(argument.keySet());
+                return keys.get(0).equals("s") &&
+                        keys.get(1).equals("since");
+            }
+        }), any());
     }
 
     private void loadSplitChanges() {

--- a/src/test/java/io/split/android/client/service/SplitsSyncHelperTest.java
+++ b/src/test/java/io/split/android/client/service/SplitsSyncHelperTest.java
@@ -1,5 +1,18 @@
 package io.split.android.client.service;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -11,6 +24,7 @@ import org.mockito.Spy;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -28,20 +42,6 @@ import io.split.android.client.storage.splits.SplitsStorage;
 import io.split.android.client.telemetry.model.OperationType;
 import io.split.android.client.telemetry.storage.TelemetryRuntimeProducer;
 import io.split.android.helpers.FileHelper;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 public class SplitsSyncHelperTest {
 
@@ -67,6 +67,7 @@ public class SplitsSyncHelperTest {
     public void setup() {
         mAutoCloseable = MockitoAnnotations.openMocks(this);
         mDefaultParams.clear();
+        mDefaultParams.put("s", "1.1");
         mDefaultParams.put("since", -1L);
         mSecondFetchParams.clear();
         mSecondFetchParams.put("since", 1506703262916L);
@@ -342,6 +343,7 @@ public class SplitsSyncHelperTest {
         mSplitsSyncHelper.sync(14829471, true, true);
 
         Map<String, Object> params = new HashMap<>();
+        params.put("s", "1.1");
         params.put("since", -1L);
         verify(mSplitsFetcher).execute(eq(params), eq(null));
         verifyNoMoreInteractions(mSplitsFetcher);
@@ -391,7 +393,8 @@ public class SplitsSyncHelperTest {
     }
 
     private Map<String, Object> getSinceParams(long since) {
-        Map<String, Object> params = new HashMap<>();
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("s", "1.1");
         params.put("since", since);
 
         return params;

--- a/src/test/java/io/split/android/http/URIBuilderTest.java
+++ b/src/test/java/io/split/android/http/URIBuilderTest.java
@@ -141,4 +141,15 @@ public class URIBuilderTest {
 
         Assert.assertEquals("users=user1&users=user2", uri.getQuery());
     }
+
+    @Test
+    public void addParamsPreservesOrder() throws URISyntaxException {
+        URI root = URI.create("https://api.split.io/");
+        URIBuilder uriBuilder = new URIBuilder(root);
+        uriBuilder.addParameter("param1", "user1");
+        uriBuilder.addParameter("param2", "user2");
+        uriBuilder.addParameter("param3", "user3");
+        URI uri = uriBuilder.build();
+        Assert.assertEquals("param1=user1&param2=user2&param3=user3", uri.getQuery());
+    }
 }


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Added `spec.gradle` file with the flags spec value.
- Added flags spec query param to `splitChanges` request.
- Modified `URIBuilder` to honor query param order.
- Adapted instrumented tests.