### PR TITLE
Params rearrangement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'kotlin-android'
 apply from: 'spec.gradle'
 
 ext {
-    splitVersion = '4.1.0-alpha-2'
+    splitVersion = '4.1.0-alpha.5'
 }
 
 android {

--- a/src/main/java/io/split/android/client/service/http/HttpFetcherImpl.java
+++ b/src/main/java/io/split/android/client/service/http/HttpFetcherImpl.java
@@ -16,6 +16,7 @@ import io.split.android.client.utils.logger.Logger;
 
 public class HttpFetcherImpl<T> implements HttpFetcher<T> {
 
+    public static final String TILL_PARAM = "till";
     private final HttpClient mClient;
     private final URI mTarget;
     private final HttpResponseParser<T> mResponseParser;
@@ -37,6 +38,11 @@ public class HttpFetcherImpl<T> implements HttpFetcher<T> {
 
         try {
             URIBuilder uriBuilder = new URIBuilder(mTarget);
+            if (params.containsKey(TILL_PARAM)) {
+                Object till = params.remove(TILL_PARAM);
+                params.put(TILL_PARAM, till);
+            }
+
             for (Map.Entry<String, Object> param : params.entrySet()) {
                 Object value = param.getValue();
                 uriBuilder.addParameter(param.getKey(), value != null ? value.toString() : "");

--- a/src/main/java/io/split/android/client/service/http/HttpSseAuthTokenFetcher.java
+++ b/src/main/java/io/split/android/client/service/http/HttpSseAuthTokenFetcher.java
@@ -63,6 +63,7 @@ public class HttpSseAuthTokenFetcher implements HttpFetcher<SseAuthenticationRes
 
     private static URI getUri(Map<String, Object> params, URI target) throws URISyntaxException {
         URIBuilder uriBuilder = new URIBuilder(target);
+
         for (Map.Entry<String, Object> param : params.entrySet()) {
             if (param.getValue() instanceof Iterable) {
                 for (Object paramValue : ((Iterable<Object>) param.getValue())) {

--- a/src/main/java/io/split/android/client/service/splits/SplitsSyncHelper.java
+++ b/src/main/java/io/split/android/client/service/splits/SplitsSyncHelper.java
@@ -12,7 +12,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import io.split.android.android_client.BuildConfig;
 import io.split.android.client.dtos.SplitChange;
 import io.split.android.client.network.SplitHttpHeadersBuilder;
 import io.split.android.client.service.ServiceConstants;

--- a/src/main/java/io/split/android/client/service/sseclient/sseclient/SseAuthenticator.java
+++ b/src/main/java/io/split/android/client/service/sseclient/sseclient/SseAuthenticator.java
@@ -7,7 +7,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Modified `HttpFetcherImpl` to always place `till` query parameter at the end, in case it exists.