### PR TITLE
Avoid retries in fetchers

### DIFF
--- a/src/main/java/io/split/android/client/network/HttpException.java
+++ b/src/main/java/io/split/android/client/network/HttpException.java
@@ -1,7 +1,23 @@
 package io.split.android.client.network;
 
+import androidx.annotation.Nullable;
+
 public class HttpException extends Exception {
+
+    private final Integer mStatusCode;
+
     public HttpException(String message) {
         super("HttpException: " + message);
+        mStatusCode = null;
+    }
+
+    public HttpException(String message, int statusCode) {
+        super("HttpException: " + message);
+        mStatusCode = statusCode;
+    }
+
+    @Nullable
+    public Integer getStatusCode() {
+        return mStatusCode;
     }
 }

--- a/src/main/java/io/split/android/client/network/HttpRequestImpl.java
+++ b/src/main/java/io/split/android/client/network/HttpRequestImpl.java
@@ -24,8 +24,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSocketFactory;
 
+import io.split.android.client.service.http.HttpStatus;
 import io.split.android.client.utils.logger.Logger;
 
 public class HttpRequestImpl implements HttpRequest {
@@ -106,6 +108,8 @@ public class HttpRequestImpl implements HttpRequest {
             throw new HttpException("URL is malformed: " + e.getLocalizedMessage());
         } catch (ProtocolException e) {
             throw new HttpException("Http method not allowed: " + e.getLocalizedMessage());
+        } catch (SSLPeerUnverifiedException e) {
+            throw new HttpException("SSL Peer Unverified: " + e.getLocalizedMessage(), HttpStatus.INTERNAL_NON_RETRYABLE.getCode());
         } catch (IOException e) {
             throw new HttpException("Something happened while retrieving data: " + e.getLocalizedMessage());
         } finally {
@@ -131,6 +135,8 @@ public class HttpRequestImpl implements HttpRequest {
             if (response.getHttpStatus() == HttpURLConnection.HTTP_PROXY_AUTH) {
                 response = handleProxyAuthentication(response, false, wasRetried);
             }
+        } catch (SSLPeerUnverifiedException e) {
+            throw new HttpException("SSL Peer Unverified: " + e.getLocalizedMessage(), HttpStatus.INTERNAL_NON_RETRYABLE.getCode());
         } catch (IOException e) {
             throw new HttpException("Something happened while posting data: " + e.getLocalizedMessage());
         } finally {

--- a/src/main/java/io/split/android/client/service/http/HttpFetcherImpl.java
+++ b/src/main/java/io/split/android/client/service/http/HttpFetcherImpl.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import java.util.Map;
 
 import io.split.android.client.network.HttpClient;
+import io.split.android.client.network.HttpException;
 import io.split.android.client.network.HttpMethod;
 import io.split.android.client.network.HttpResponse;
 import io.split.android.client.network.URIBuilder;
@@ -53,7 +54,8 @@ public class HttpFetcherImpl<T> implements HttpFetcher<T> {
                 Logger.v("Received from: " + builtUri + " -> " + response.getData());
             }
             if (!response.isSuccess()) {
-                throw new IllegalStateException("http return code " + response.getHttpStatus());
+                int httpStatus = response.getHttpStatus();
+                throw new HttpFetcherException(mTarget.toString(), "http return code " + httpStatus, httpStatus);
             }
 
             responseData = mResponseParser.parse(response.getData());
@@ -61,6 +63,10 @@ public class HttpFetcherImpl<T> implements HttpFetcher<T> {
             if (responseData == null) {
                 throw new IllegalStateException("Wrong data received from split changes server");
             }
+        } catch (HttpFetcherException httpFetcherException) {
+            throw httpFetcherException;
+        } catch (HttpException e) {
+            throw new HttpFetcherException(mTarget.toString(), e.getLocalizedMessage(), e.getStatusCode());
         } catch (Exception e) {
             throw new HttpFetcherException(mTarget.toString(), e.getLocalizedMessage());
         }

--- a/src/main/java/io/split/android/client/service/http/HttpStatus.java
+++ b/src/main/java/io/split/android/client/service/http/HttpStatus.java
@@ -4,7 +4,8 @@ import androidx.annotation.Nullable;
 
 public enum HttpStatus {
 
-    URI_TOO_LONG(414, "URI Too Long");
+    URI_TOO_LONG(414, "URI Too Long"),
+    INTERNAL_NON_RETRYABLE(9009, "Non retryable");
 
     private final int mCode;
     private final String mDescription;

--- a/src/main/java/io/split/android/client/service/splits/SplitsSyncHelper.java
+++ b/src/main/java/io/split/android/client/service/splits/SplitsSyncHelper.java
@@ -90,6 +90,9 @@ public class SplitsSyncHelper {
 
             if (HttpStatus.fromCode(e.getHttpStatus()) == HttpStatus.URI_TOO_LONG) {
                 Logger.e("SDK initialization: the amount of flag sets provided is big, causing URI length error");
+            }
+
+            if (isNotRetryable(e.getHttpStatus())) {
                 return SplitTaskExecutionInfo.error(SplitTaskType.SPLITS_SYNC,
                         Collections.singletonMap(SplitTaskExecutionInfo.DO_NOT_RETRY, true));
             }
@@ -199,5 +202,10 @@ public class SplitsSyncHelper {
             return SplitHttpHeadersBuilder.noCacheHeaders();
         }
         return null;
+    }
+
+    private static boolean isNotRetryable(Integer httpStatus) {
+        return HttpStatus.fromCode(httpStatus) == HttpStatus.URI_TOO_LONG ||
+                HttpStatus.fromCode(httpStatus) == HttpStatus.INTERNAL_NON_RETRYABLE;
     }
 }

--- a/src/test/java/io/split/android/client/service/HttpFetcherTest.java
+++ b/src/test/java/io/split/android/client/service/HttpFetcherTest.java
@@ -254,7 +254,6 @@ public class HttpFetcherTest {
             exceptionWasThrown = true;
         }
 
-
         Assert.assertTrue(exceptionWasThrown);
     }
 
@@ -317,6 +316,26 @@ public class HttpFetcherTest {
         }
 
         verifyQuery("s=1.1&since=-1&till=100");
+    }
+
+    @Test
+    public void httpExceptionWithStatusCodeAddsStatusCodeToHttpFetcherException() throws HttpException {
+        HttpFetcher<SplitChange> fetcher = getSplitChangeHttpFetcher();
+
+        HttpRequest request = mock(HttpRequest.class);
+        when(request.execute()).thenThrow(new HttpException("Not found", 404));
+        when(mClientMock.request(any(), any(), any(), any())).thenReturn(request);
+
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("since", "-1");
+        params.put("till", "100");
+        params.put("sets", "flag_set1,flagset2");
+
+        try {
+            fetcher.execute(params, null);
+        } catch (HttpFetcherException e) {
+            Assert.assertEquals(404, e.getHttpStatus().intValue());
+        }
     }
 
     @NonNull

--- a/src/test/java/io/split/android/client/service/SplitsSyncHelperTest.java
+++ b/src/test/java/io/split/android/client/service/SplitsSyncHelperTest.java
@@ -372,6 +372,28 @@ public class SplitsSyncHelperTest {
     }
 
     @Test
+    public void returnTaskInfoToDoNotRetryWhenHttpFetcherExceptionStatusCodeIs9009() throws HttpFetcherException {
+        when(mSplitsFetcher.execute(eq(mDefaultParams), any()))
+                .thenThrow(new HttpFetcherException("error", "error", 9009));
+        when(mSplitsStorage.getTill()).thenReturn(-1L);
+
+        SplitTaskExecutionInfo result = mSplitsSyncHelper.sync(-1);
+
+        assertEquals(true, result.getBoolValue(SplitTaskExecutionInfo.DO_NOT_RETRY));
+    }
+
+    @Test
+    public void doNotRetryFlagIsNullWhenFetcherExceptionStatusCodeIsNot9009() throws HttpFetcherException {
+        when(mSplitsFetcher.execute(eq(mDefaultParams), any()))
+                .thenThrow(new HttpFetcherException("error", "error", 500));
+        when(mSplitsStorage.getTill()).thenReturn(-1L);
+
+        SplitTaskExecutionInfo result = mSplitsSyncHelper.sync(-1);
+
+        assertNull(result.getBoolValue(SplitTaskExecutionInfo.DO_NOT_RETRY));
+    }
+
+    @Test
     public void defaultQueryParamOrderIsCorrect() throws HttpFetcherException {
         mSplitsSyncHelper.sync(100);
 


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Added functionality to avoid retries in fetchers. They now return an internal status code that can be interpreted by tasks to return a `DO_NOT_RETRY` flag as part of the task execution result.