### PR TITLE
Wildcards for pinned host

### DIFF
--- a/src/main/java/io/split/android/client/network/CertificateCheckerHelper.java
+++ b/src/main/java/io/split/android/client/network/CertificateCheckerHelper.java
@@ -1,0 +1,45 @@
+package io.split.android.client.network;
+
+import androidx.annotation.Nullable;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+class CertificateCheckerHelper {
+
+    @Nullable
+    static Set<CertificatePin> getPinsForHost(String pattern, Map<String, Set<CertificatePin>> configuredPins) {
+        Set<CertificatePin> hostPins = configuredPins.get(pattern);
+        Set<CertificatePin> wildcardPins = new LinkedHashSet<>();
+
+        for (String configuredHost : configuredPins.keySet()) {
+            if (configuredHost.startsWith("**.")) {
+                String configuredSubdomain = configuredHost.substring(3);
+                if (pattern.regionMatches(pattern.length() - configuredSubdomain.length(), configuredSubdomain, 0, configuredSubdomain.length())) {
+                    wildcardPins.addAll(configuredPins.get(configuredHost));
+                }
+            } else if (configuredHost.startsWith("*.")) {
+                String configuredSubdomain = configuredHost.substring(2);
+                int index = pattern.lastIndexOf(configuredSubdomain);
+                if (index != -1 && pattern.charAt(index - 1) == '.' &&
+                        pattern.regionMatches(index, configuredSubdomain, 0, configuredSubdomain.length())) {
+                    String[] hostParts = pattern.substring(0, index - 1).split("\\.");
+                    if (hostParts.length == 1) {
+                        wildcardPins.addAll(configuredPins.get(configuredHost));
+                    }
+                }
+            }
+        }
+
+        if (hostPins == null && wildcardPins.isEmpty()) {
+            return null;
+        }
+
+        if (hostPins != null) {
+            wildcardPins.addAll(hostPins);
+        }
+
+        return wildcardPins;
+    }
+}

--- a/src/main/java/io/split/android/client/network/CertificateCheckerImpl.java
+++ b/src/main/java/io/split/android/client/network/CertificateCheckerImpl.java
@@ -1,5 +1,7 @@
 package io.split.android.client.network;
 
+import static io.split.android.client.network.CertificateCheckerHelper.getPinsForHost;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -51,7 +53,7 @@ class CertificateCheckerImpl implements CertificateChecker {
     @Override
     public void checkPins(HttpsURLConnection httpsConnection) throws SSLPeerUnverifiedException {
         String host = httpsConnection.getURL().getHost();
-        Set<CertificatePin> pinsForHost = mConfiguredPins.get(host);
+        Set<CertificatePin> pinsForHost = getPinsForHost(host, mConfiguredPins);
         if (pinsForHost == null || pinsForHost.isEmpty()) {
             Logger.d("No certificate pins configured for " + host + ". Skipping pinning verification.");
             return;
@@ -70,7 +72,7 @@ class CertificateCheckerImpl implements CertificateChecker {
                         pinnedCertificate.getAlgorithm(),
                         certificate.getPublicKey().getEncoded());
                 if (Arrays.equals(pin, pinnedCertificate.getPin())) {
-                    Logger.d("Certificate pinning verification successful for " + host);
+                    Logger.v("Certificate pinning verification successful for " + host);
                     return;
                 }
             }

--- a/src/test/java/io/split/android/client/network/CertificateCheckerHelperTest.java
+++ b/src/test/java/io/split/android/client/network/CertificateCheckerHelperTest.java
@@ -1,0 +1,44 @@
+package io.split.android.client.network;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class CertificateCheckerHelperTest {
+
+    @Test
+    public void getPinsForHost() {
+        Map<String, Set<CertificatePin>> pins = new HashMap<>();
+        Set<CertificatePin> pins1 = Collections.singleton(new CertificatePin(new byte[]{1, 2}, "sha256"));
+        Set<CertificatePin> pins2 = Collections.singleton(new CertificatePin(new byte[]{3, 4}, "sha256"));
+        Set<CertificatePin> pins4 = Collections.singleton(new CertificatePin(new byte[]{7, 8}, "sha256"));
+        pins.put("*.example.com", pins1);
+        pins.put("**.example.com", pins2);
+        pins.put("www.sub.example.com", pins4);
+
+        Set<CertificatePin> result1 = CertificateCheckerHelper.getPinsForHost("sub.example.com", pins);
+        Set<CertificatePin> result2 = CertificateCheckerHelper.getPinsForHost("www.sub.example.com", pins);
+        Set<CertificatePin> result4 = CertificateCheckerHelper.getPinsForHost("*.", pins);
+        Set<CertificatePin> result5 = CertificateCheckerHelper.getPinsForHost("**.", pins);
+
+        // sub.example.com matches with *.example.com & **.example.com
+        assertEquals(2, result1.size());
+        assertTrue(result1.contains(new CertificatePin(new byte[]{1, 2}, "sha256")));
+        assertTrue(result1.contains(new CertificatePin(new byte[]{3, 4}, "sha256")));
+
+        // www.sub.example.com matchers with **.example.com & www.sub.example.com
+        assertEquals(2, result2.size());
+        assertTrue(result2.contains(new CertificatePin(new byte[]{3, 4}, "sha256")));
+        assertTrue(result2.contains(new CertificatePin(new byte[]{7, 8}, "sha256")));
+
+        assertNull(result4);
+        assertNull(result5);
+    }
+}


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Added functionality to allow specifying a pattern instead of a full host for certificate pinning. Patterns that start with `*` will match one subdomain; patterns that start with `**` will match any number of subdomains.