### PR TITLE
Modify gradle files for modules reusability

### DIFF
--- a/android-commons-root.gradle
+++ b/android-commons-root.gradle
@@ -1,3 +1,1 @@
-// Minimal root build file used when android-client is included in the POC project.
-// The full android-client/build.gradle references submodules (:main, :events, etc.)
-// that are not included here, so we use this stub instead.
+// Minimal root build file used when android-client is included as a subproject.

--- a/android-commons-root.gradle
+++ b/android-commons-root.gradle
@@ -1,0 +1,3 @@
+// Minimal root build file used when android-client is included in the POC project.
+// The full android-client/build.gradle references submodules (:main, :events, etc.)
+// that are not included here, so we use this stub instead.

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.library'
 }
 
-apply from: "$rootDir/gradle/common-android-library.gradle"
+apply from: "$projectDir/../gradle/common-android-library.gradle"
 
 android {
     namespace 'io.split.android.client.api'

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 apply plugin: 'com.android.fused-library'
 apply plugin: 'com.vanniktech.maven.publish'
-apply from: "$rootDir/gradle/jacoco-root.gradle"
+apply from: "$projectDir/gradle/jacoco-root.gradle"
 
 ext {
     splitVersion = '5.5.0'
@@ -68,7 +68,7 @@ tasks.register('sonar') {
         if (sonarOrg) cmd.add("-Dsonar.organization=${sonarOrg}")
         cmd.add("-Dsonar.projectVersion=${splitVersion}")
         
-        def proc = new ProcessBuilder(cmd).directory(rootDir).inheritIO().start()
+        def proc = new ProcessBuilder(cmd).directory(projectDir).inheritIO().start()
         if (proc.waitFor() != 0) {
             throw new GradleException("sonar-scanner failed")
         }

--- a/events-domain/build.gradle
+++ b/events-domain/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.library'
 }
 
-apply from: "$rootDir/gradle/common-android-library.gradle"
+apply from: "$projectDir/../gradle/common-android-library.gradle"
 
 android {
     namespace 'io.split.android.client.events'

--- a/events/build.gradle
+++ b/events/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.library'
 }
 
-apply from: "$rootDir/gradle/common-android-library.gradle"
+apply from: "$projectDir/../gradle/common-android-library.gradle"
 
 android {
     namespace 'io.harness.events'

--- a/gradle/common-android-library.gradle
+++ b/gradle/common-android-library.gradle
@@ -30,4 +30,4 @@ if (kotlinCompileClass != null) {
 }
 
 // Enable Jacoco coverage configuration for all Android library modules
-apply from: "$rootDir/gradle/jacoco-android.gradle"
+apply from: "$projectDir/../gradle/jacoco-android.gradle"

--- a/http-api/build.gradle
+++ b/http-api/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.library'
 }
 
-apply from: "$rootDir/gradle/common-android-library.gradle"
+apply from: "$projectDir/../gradle/common-android-library.gradle"
 
 android {
     namespace 'io.split.android.client.network.api'
@@ -15,7 +15,7 @@ android {
 
 dependencies {
     implementation libs.annotation
-    implementation project(':logger')
+    implementation project(':android-client:logger')
 
     testImplementation libs.junit4
     testImplementation libs.mockitoCore

--- a/http-api/build.gradle
+++ b/http-api/build.gradle
@@ -15,7 +15,7 @@ android {
 
 dependencies {
     implementation libs.annotation
-    implementation project(':android-client:logger')
+    implementation project(':logger')
 
     testImplementation libs.junit4
     testImplementation libs.mockitoCore

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.library'
 }
 
-apply from: "$rootDir/gradle/common-android-library.gradle"
+apply from: "$projectDir/../gradle/common-android-library.gradle"
 
 android {
     namespace 'io.split.android.client.network.http'
@@ -15,8 +15,8 @@ android {
 
 dependencies {
     implementation libs.annotation
-    implementation project(':logger')
-    api project(':http-api')
+    implementation project(':android-client:logger')
+    api project(':android-client:http-api')
 
     testImplementation libs.junit4
     testImplementation libs.mockitoCore

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -15,8 +15,8 @@ android {
 
 dependencies {
     implementation libs.annotation
-    implementation project(':android-client:logger')
-    api project(':android-client:http-api')
+    implementation project(':logger')
+    api project(':http-api')
 
     testImplementation libs.junit4
     testImplementation libs.mockitoCore

--- a/logger/build.gradle
+++ b/logger/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.library'
 }
 
-apply from: "$rootDir/gradle/common-android-library.gradle"
+apply from: "$projectDir/../gradle/common-android-library.gradle"
 
 android {
     namespace 'io.split.android.client.logger'

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -2,14 +2,14 @@ plugins {
     id 'com.android.library'
 }
 
-apply from: "$rootDir/gradle/common-android-library.gradle"
+apply from: "$projectDir/../gradle/common-android-library.gradle"
 
 android {
     namespace 'io.split.android.client.main'
 
     defaultConfig {
         multiDexEnabled true
-        consumerProguardFiles "$rootDir/split-proguard-rules.pro"
+        consumerProguardFiles "$projectDir/../split-proguard-rules.pro"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
 


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Modify gradle files for modules reusability. Using rootDir conflicts when consuming from another project.