### PR TITLE
Centralize version header value

### DIFF
--- a/main/src/main/java/io/split/android/client/SplitClientConfig.java
+++ b/main/src/main/java/io/split/android/client/SplitClientConfig.java
@@ -13,9 +13,9 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
 
-import io.split.android.client.main.BuildConfig;
 import io.split.android.client.impressions.ImpressionListener;
 import io.split.android.client.network.CertificatePinningConfiguration;
+import io.split.android.client.network.SdkVersionProvider;
 import io.split.android.client.network.DevelopmentSslConfig;
 import io.split.android.client.network.HttpProxy;
 import io.split.android.client.network.ProxyConfiguration;
@@ -242,7 +242,7 @@ public class SplitClientConfig {
 
         mUserConsent = userConsent;
 
-        splitSdkVersion = "Android-" + BuildConfig.SPLIT_VERSION_NAME;
+        splitSdkVersion = SdkVersionProvider.getSdkVersion();
 
         mShouldRecordTelemetry = shouldRecordTelemetry;
 

--- a/main/src/main/java/io/split/android/client/network/SdkVersionProvider.java
+++ b/main/src/main/java/io/split/android/client/network/SdkVersionProvider.java
@@ -1,0 +1,10 @@
+package io.split.android.client.network;
+
+import io.split.android.client.main.BuildConfig;
+
+public class SdkVersionProvider {
+
+    public static String getSdkVersion() {
+        return "Android-" + BuildConfig.SPLIT_VERSION_NAME;
+    }
+}

--- a/main/src/main/java/io/split/android/client/service/workmanager/HttpClientProvider.java
+++ b/main/src/main/java/io/split/android/client/service/workmanager/HttpClientProvider.java
@@ -6,7 +6,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
-import io.split.android.client.main.BuildConfig;
 import io.split.android.client.dtos.HttpProxyDto;
 import io.split.android.client.network.BasicCredentialsProvider;
 import io.split.android.client.network.BearerCredentialsProvider;
@@ -14,6 +13,7 @@ import io.split.android.client.network.CertificatePinningConfiguration;
 import io.split.android.client.network.CertificatePinningConfigurationProvider;
 import io.split.android.client.network.HttpClient;
 import io.split.android.client.network.HttpClientImpl;
+import io.split.android.client.network.SdkVersionProvider;
 import io.split.android.client.network.HttpProxy;
 import io.split.android.client.network.SplitHttpHeadersBuilder;
 import io.split.android.client.storage.cipher.SplitCipherFactory;
@@ -43,7 +43,7 @@ class HttpClientProvider {
                 .build();
 
         SplitHttpHeadersBuilder headersBuilder = new SplitHttpHeadersBuilder();
-        headersBuilder.setClientVersion(BuildConfig.SPLIT_VERSION_NAME);
+        headersBuilder.setClientVersion(SdkVersionProvider.getSdkVersion());
         headersBuilder.setApiToken(apiKey);
         headersBuilder.addJsonTypeHeaders();
         httpClient.addHeaders(headersBuilder.build());

--- a/main/src/test/java/io/split/android/client/network/SdkVersionProviderTest.java
+++ b/main/src/test/java/io/split/android/client/network/SdkVersionProviderTest.java
@@ -1,0 +1,21 @@
+package io.split.android.client.network;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class SdkVersionProviderTest {
+
+    @Test
+    public void getSdkVersionStartsWithAndroidPrefix() {
+        assertTrue(SdkVersionProvider.getSdkVersion().startsWith("Android-"));
+    }
+
+    @Test
+    public void getSdkVersionContainsNonEmptyVersionAfterPrefix() {
+        String version = SdkVersionProvider.getSdkVersion();
+        String suffix = version.substring("Android-".length());
+        assertFalse(suffix.isEmpty());
+    }
+}


### PR DESCRIPTION
# Android SDK

## What did you accomplish?

- Centralize the generation of the `SplitSDKVersion` header value. This fixes missing `Android-` prefix for background sync requests.